### PR TITLE
[Added] Feature: Unsafe json api

### DIFF
--- a/bench/src/test/scala/io/techcode/streamy/util/json/JsonParserBench.scala
+++ b/bench/src/test/scala/io/techcode/streamy/util/json/JsonParserBench.scala
@@ -52,22 +52,16 @@ object JsonParserBench {
   object Sample {
 
     val JsonObjImpl: JsObject = Json.obj(
-      "int" -> Int.MaxValue,
-      "long" -> Long.MaxValue,
-      "float" -> Float.MaxValue,
-      "double" -> Double.MaxValue,
+      "int" -> 0,
+      "long" -> 0L,
+      "float" -> 0F,
+      "double" -> 0D,
       "string" -> "string"
     )
 
-    val StringImpl: String = Json.obj(
-      "int" -> Int.MaxValue,
-      "long" -> Long.MaxValue,
-      "float" -> Float.MaxValue,
-      "double" -> Double.MaxValue,
-      "string" -> "string"
-    ).toString
+    val StringImpl: String = JsonObjImpl.toString
 
-    val ByteStringImpl: ByteString = ByteString(StringImpl)
+    val ByteStringImpl: ByteString = ByteString(StringImpl).compact
 
     val BytesImpl: Array[Byte] = ByteStringImpl.toArray[Byte]
 

--- a/core/src/main/scala/io/techcode/streamy/util/Binder.scala
+++ b/core/src/main/scala/io/techcode/streamy/util/Binder.scala
@@ -182,37 +182,37 @@ sealed abstract class SomeBinder(val key: String) extends Binder {
 case class StringBinder(override val key: String, charset: Charset = StandardCharsets.UTF_8) extends SomeBinder(key) {
 
   def apply(value: Boolean)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsString(value.toString))
+    builder += (key -> JsString.fromLiteral(value.toString))
     true
   }
 
   def apply(value: Int)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsString(value.toString))
+    builder += (key -> JsString.fromLiteral(value.toString))
     true
   }
 
   def apply(value: Long)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsString(value.toString))
+    builder += (key -> JsString.fromLiteral(value.toString))
     true
   }
 
   def apply(value: Float)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsString(value.toString))
+    builder += (key -> JsString.fromLiteral(value.toString))
     true
   }
 
   def apply(value: Double)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsString(value.toString))
+    builder += (key -> JsString.fromLiteral(value.toString))
     true
   }
 
   def apply(value: String)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsString(value))
+    builder += (key -> JsString.fromLiteral(value))
     true
   }
 
   def apply(value: ByteString)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsString(value.decodeString(charset)))
+    builder += (key -> JsString.fromLiteral(value.decodeString(charset)))
     true
   }
 
@@ -248,37 +248,37 @@ case class StringBinder(override val key: String, charset: Charset = StandardCha
 case class BytesBinder(override val key: String) extends SomeBinder(key) {
 
   def apply(value: Boolean)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsBytes(ByteString(value.toString)))
+    builder += (key -> JsBytes.fromLiteral(ByteString(value.toString)))
     true
   }
 
   def apply(value: Int)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsBytes(ByteString(value.toString)))
+    builder += (key -> JsBytes.fromLiteral(ByteString(value.toString)))
     true
   }
 
   def apply(value: Long)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsBytes(ByteString(value.toString)))
+    builder += (key -> JsBytes.fromLiteral(ByteString(value.toString)))
     true
   }
 
   def apply(value: Float)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsBytes(ByteString(value.toString)))
+    builder += (key -> JsBytes.fromLiteral(ByteString(value.toString)))
     true
   }
 
   def apply(value: Double)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsBytes(ByteString(value.toString)))
+    builder += (key -> JsBytes.fromLiteral(ByteString(value.toString)))
     true
   }
 
   def apply(value: String)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsBytes(ByteString(value)))
+    builder += (key -> JsBytes.fromLiteral(ByteString(value)))
     true
   }
 
   def apply(value: ByteString)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsBytes(value))
+    builder += (key -> JsBytes.fromLiteral(value))
     true
   }
 
@@ -314,40 +314,40 @@ case class BytesBinder(override val key: String) extends SomeBinder(key) {
 case class IntBinder(override val key: String) extends SomeBinder(key) {
 
   def apply(value: Boolean)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsInt(if (value) 1 else 0))
+    builder += (key -> JsInt.fromLiteral(if (value) 1 else 0))
     true
   }
 
   def apply(value: Int)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsInt(value))
+    builder += (key -> JsInt.fromLiteral(value))
     true
   }
 
   def apply(value: Long)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsInt(value.toInt))
+    builder += (key -> JsInt.fromLiteral(value.toInt))
     true
   }
 
   def apply(value: Float)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsInt(value.toInt))
+    builder += (key -> JsInt.fromLiteral(value.toInt))
     true
   }
 
   def apply(value: Double)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsInt(value.toInt))
+    builder += (key -> JsInt.fromLiteral(value.toInt))
     true
   }
 
   def apply(value: String)(implicit builder: JsObjectBuilder): Boolean = {
     Option(Ints.tryParse(value)).exists { v =>
-      builder += (key -> JsInt(v))
+      builder += (key -> JsInt.fromLiteral(v))
       true
     }
   }
 
   def apply(value: ByteString)(implicit builder: JsObjectBuilder): Boolean =
     Option(Ints.tryParse(value.decodeString(StandardCharsets.US_ASCII))).exists { v =>
-      builder += (key -> JsInt(v))
+      builder += (key -> JsInt.fromLiteral(v))
       true
     }
 
@@ -383,39 +383,39 @@ case class IntBinder(override val key: String) extends SomeBinder(key) {
 case class LongBinder(override val key: String) extends SomeBinder(key) {
 
   def apply(value: Boolean)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsLong(if (value) 1 else 0))
+    builder += (key -> JsLong.fromLiteral(if (value) 1 else 0))
     true
   }
 
   def apply(value: Int)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsLong(value))
+    builder += (key -> JsLong.fromLiteral(value))
     true
   }
 
   def apply(value: Long)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsLong(value))
+    builder += (key -> JsLong.fromLiteral(value))
     true
   }
 
   def apply(value: Float)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsLong(value.toLong))
+    builder += (key -> JsLong.fromLiteral(value.toLong))
     true
   }
 
   def apply(value: Double)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsLong(value.toLong))
+    builder += (key -> JsLong.fromLiteral(value.toLong))
     true
   }
 
   def apply(value: String)(implicit builder: JsObjectBuilder): Boolean =
     Option(Longs.tryParse(value)).exists { v =>
-      builder += (key -> JsLong(v))
+      builder += (key -> JsLong.fromLiteral(v))
       true
     }
 
   def apply(value: ByteString)(implicit builder: JsObjectBuilder): Boolean =
     Option(Longs.tryParse(value.decodeString(StandardCharsets.US_ASCII))).exists { v =>
-      builder += (key -> JsLong(v))
+      builder += (key -> JsLong.fromLiteral(v))
       true
     }
 
@@ -451,39 +451,39 @@ case class LongBinder(override val key: String) extends SomeBinder(key) {
 case class FloatBinder(override val key: String) extends SomeBinder(key) {
 
   def apply(value: Boolean)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsFloat(if (value) 1 else 0))
+    builder += (key -> JsFloat.fromLiteral(if (value) 1 else 0))
     true
   }
 
   def apply(value: Int)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsFloat(value.toFloat))
+    builder += (key -> JsFloat.fromLiteral(value.toFloat))
     true
   }
 
   def apply(value: Long)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsFloat(value.toFloat))
+    builder += (key -> JsFloat.fromLiteral(value.toFloat))
     true
   }
 
   def apply(value: Float)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsFloat(value))
+    builder += (key -> JsFloat.fromLiteral(value))
     true
   }
 
   def apply(value: Double)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsFloat(value.toFloat))
+    builder += (key -> JsFloat.fromLiteral(value.toFloat))
     true
   }
 
   def apply(value: String)(implicit builder: JsObjectBuilder): Boolean =
     Option(Floats.tryParse(value)).exists { v =>
-      builder += (key -> JsFloat(v))
+      builder += (key -> JsFloat.fromLiteral(v))
       true
     }
 
   def apply(value: ByteString)(implicit builder: JsObjectBuilder): Boolean =
     Option(Floats.tryParse(value.decodeString(StandardCharsets.US_ASCII))).exists { v =>
-      builder += (key -> JsFloat(v))
+      builder += (key -> JsFloat.fromLiteral(v))
       true
     }
 
@@ -519,39 +519,39 @@ case class FloatBinder(override val key: String) extends SomeBinder(key) {
 case class DoubleBinder(override val key: String) extends SomeBinder(key) {
 
   def apply(value: Boolean)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsDouble(if (value) 1 else 0))
+    builder += (key -> JsDouble.fromLiteral(if (value) 1 else 0))
     true
   }
 
   def apply(value: Int)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsDouble(value.toDouble))
+    builder += (key -> JsDouble.fromLiteral(value.toDouble))
     true
   }
 
   def apply(value: Long)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsDouble(value.toDouble))
+    builder += (key -> JsDouble.fromLiteral(value.toDouble))
     true
   }
 
   def apply(value: Float)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsDouble(value))
+    builder += (key -> JsDouble.fromLiteral(value))
     true
   }
 
   def apply(value: Double)(implicit builder: JsObjectBuilder): Boolean = {
-    builder += (key -> JsDouble(value.toDouble))
+    builder += (key -> JsDouble.fromLiteral(value.toDouble))
     true
   }
 
   def apply(value: String)(implicit builder: JsObjectBuilder): Boolean =
     Option(Doubles.tryParse(value)).exists { v =>
-      builder += (key -> JsDouble(v))
+      builder += (key -> JsDouble.fromLiteral(v))
       true
     }
 
   def apply(value: ByteString)(implicit builder: JsObjectBuilder): Boolean =
     Option(Doubles.tryParse(value.decodeString(StandardCharsets.US_ASCII))).exists { v =>
-      builder += (key -> JsDouble(v))
+      builder += (key -> JsDouble.fromLiteral(v))
       true
     }
 

--- a/core/src/main/scala/io/techcode/streamy/util/json/JsonImplicit.scala
+++ b/core/src/main/scala/io/techcode/streamy/util/json/JsonImplicit.scala
@@ -39,7 +39,7 @@ trait JsonImplicit {
     * @param value js value.
     * @return string.
     */
-  implicit def jsonToString(value: Json): String = value.toString
+  implicit def jsonToString(value: Json): String = Json.printStringUnsafe(value)
 
   /**
     * Convert a string to json value.
@@ -47,7 +47,7 @@ trait JsonImplicit {
     * @param value string value.
     * @return json.
     */
-  implicit def stringToJson(value: String): Json = JsString(value)
+  implicit def stringToJson(value: String): Json = JsString.fromLiteral(value)
 
   /**
     * Convert a float to json value.
@@ -55,7 +55,7 @@ trait JsonImplicit {
     * @param value float value.
     * @return json.
     */
-  implicit def floatToJson(value: Float): Json = JsFloat(value)
+  implicit def floatToJson(value: Float): Json = JsFloat.fromLiteral(value)
 
   /**
     * Convert a double to json value.
@@ -63,7 +63,7 @@ trait JsonImplicit {
     * @param value double value.
     * @return json.
     */
-  implicit def doubleToJson(value: Double): Json = JsDouble(value)
+  implicit def doubleToJson(value: Double): Json = JsDouble.fromLiteral(value)
 
   /**
     * Convert a byte to json value.
@@ -71,7 +71,7 @@ trait JsonImplicit {
     * @param value byte value.
     * @return json.
     */
-  implicit def byteToJson(value: Byte): Json = JsInt(value)
+  implicit def byteToJson(value: Byte): Json = JsInt.fromLiteral(value)
 
   /**
     * Convert a short to json value.
@@ -79,7 +79,7 @@ trait JsonImplicit {
     * @param value short value.
     * @return json.
     */
-  implicit def shortToJson(value: Short): Json = JsInt(value)
+  implicit def shortToJson(value: Short): Json = JsInt.fromLiteral(value)
 
   /**
     * Convert a int to json value.
@@ -87,7 +87,7 @@ trait JsonImplicit {
     * @param value int value.
     * @return json.
     */
-  implicit def intToJson(value: Int): Json = JsInt(value)
+  implicit def intToJson(value: Int): Json = JsInt.fromLiteral(value)
 
   /**
     * Convert a long to json value.
@@ -95,7 +95,7 @@ trait JsonImplicit {
     * @param value long value.
     * @return json.
     */
-  implicit def longToJson(value: Long): Json = JsLong(value)
+  implicit def longToJson(value: Long): Json = JsLong.fromLiteral(value)
 
   /**
     * Convert a boolean to json value.
@@ -111,7 +111,7 @@ trait JsonImplicit {
     * @param value byte string value.
     * @return json.
     */
-  implicit def byteStringToJson(value: ByteString): Json = JsBytes(value)
+  implicit def byteStringToJson(value: ByteString): Json = JsBytes.fromLiteral(value)
 
   /**
     * Convert a big decimal to json value.
@@ -119,7 +119,7 @@ trait JsonImplicit {
     * @param value big decimal value.
     * @return json.
     */
-  implicit def bigDecimalToJson(value: BigDecimal): Json = JsBigDecimal(value)
+  implicit def bigDecimalToJson(value: BigDecimal): Json = JsBigDecimal.fromLiteral(value)
 
   // Json reader to support pureconfig
   implicit val jsonReader: ConfigReader[Json] = ConfigReader.fromString[Json](ConvertHelpers.tryF(Json.parseString(_).toTry))

--- a/core/src/main/scala/io/techcode/streamy/util/parser/Parser.scala
+++ b/core/src/main/scala/io/techcode/streamy/util/parser/Parser.scala
@@ -100,7 +100,7 @@ trait Parser[In, Out] {
     *
     * @return length of the input data.
     */
-  final def length: Int = _length
+  @inline final def length: Int = _length
 
   /**
     * The index of the next (yet unmatched) character.

--- a/core/src/test/scala/io/techcode/streamy/util/BinderSpec.scala
+++ b/core/src/test/scala/io/techcode/streamy/util/BinderSpec.scala
@@ -23,7 +23,7 @@
  */
 package io.techcode.streamy.util
 
-import akka.util.ByteString
+import akka.util.{ByteString, ByteStringBuilder}
 import io.techcode.streamy.util.json._
 import io.techcode.streamy.util.lang.CharBuilder
 import org.scalatest._
@@ -37,65 +37,65 @@ class BinderSpec extends WordSpecLike with Matchers {
     "convert correctly a boolean in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       StringBinder("foobar")(true)
-      builder.result() should equal(Json.obj("foobar" -> JsString("true")))
+      builder.result() should equal(Json.obj("foobar" -> JsString.fromLiteral("true")))
     }
 
     "convert correctly an int in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       StringBinder("foobar")(1)
-      builder.result() should equal(Json.obj("foobar" -> JsString("1")))
+      builder.result() should equal(Json.obj("foobar" -> JsString.fromLiteral("1")))
     }
 
     "convert correctly a long in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       StringBinder("foobar")(1L)
-      builder.result() should equal(Json.obj("foobar" -> JsString("1")))
+      builder.result() should equal(Json.obj("foobar" -> JsString.fromLiteral("1")))
     }
 
     "convert correctly a float in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       StringBinder("foobar")(1.0F)
-      builder.result() should equal(Json.obj("foobar" -> JsString("1.0")))
+      builder.result() should equal(Json.obj("foobar" -> JsString.fromLiteral("1.0")))
     }
 
     "convert correctly a double in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       StringBinder("foobar")(1.0D)
-      builder.result() should equal(Json.obj("foobar" -> JsString("1.0")))
+      builder.result() should equal(Json.obj("foobar" -> JsString.fromLiteral("1.0")))
     }
 
     "convert correctly a string in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       StringBinder("foobar")("test")
-      builder.result() should equal(Json.obj("foobar" -> JsString("test")))
+      builder.result() should equal(Json.obj("foobar" -> JsString.fromLiteral("test")))
     }
 
     "convert correctly a bytestring in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       StringBinder("foobar")(ByteString("test"))
-      builder.result() should equal(Json.obj("foobar" -> JsString("test")))
+      builder.result() should equal(Json.obj("foobar" -> JsString.fromLiteral("test")))
     }
 
     "convert correctly a json value in bytestring" in {
-      implicit val builder = ByteString.newBuilder
+      implicit val builder: ByteStringBuilder = ByteString.newBuilder
       StringBinder("foobar").applyByteString(Json.obj("foobar" -> "test"))
       builder.result() should equal(ByteString("test"))
     }
 
     "fail to convert a json value in bytestring" in {
-      implicit val builder = ByteString.newBuilder
+      implicit val builder: ByteStringBuilder = ByteString.newBuilder
       StringBinder("foobar").applyByteString(Json.obj("foobar" -> 1))
       builder.result() should equal(ByteString.empty)
     }
 
     "convert correctly a json value in string" in {
-      implicit val builder = new CharBuilder
+      implicit val builder: CharBuilder = new CharBuilder
       StringBinder("foobar").applyString(Json.obj("foobar" -> "test"))
       builder.toString should equal("test")
     }
 
     "fail to convert a json value in string" in {
-      implicit val builder = new CharBuilder
+      implicit val builder: CharBuilder = new CharBuilder
       StringBinder("foobar").applyString(Json.obj("foobar" -> 1))
       builder.toString should equal("")
     }
@@ -105,37 +105,37 @@ class BinderSpec extends WordSpecLike with Matchers {
     "convert correctly a boolean in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       IntBinder("foobar")(true)
-      builder.result() should equal(Json.obj("foobar" -> JsInt(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsInt.fromLiteral(1)))
     }
 
     "convert correctly an int in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       IntBinder("foobar")(1)
-      builder.result() should equal(Json.obj("foobar" -> JsInt(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsInt.fromLiteral(1)))
     }
 
     "convert correctly a long in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       IntBinder("foobar")(1L)
-      builder.result() should equal(Json.obj("foobar" -> JsInt(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsInt.fromLiteral(1)))
     }
 
     "convert correctly a float in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       IntBinder("foobar")(1.0F)
-      builder.result() should equal(Json.obj("foobar" -> JsInt(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsInt.fromLiteral(1)))
     }
 
     "convert correctly a double in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       IntBinder("foobar")(1.0D)
-      builder.result() should equal(Json.obj("foobar" -> JsInt(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsInt.fromLiteral(1)))
     }
 
     "convert correctly a string in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       IntBinder("foobar")("1")
-      builder.result() should equal(Json.obj("foobar" -> JsInt(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsInt.fromLiteral(1)))
     }
 
     "fail to convert a string in mapping" in {
@@ -145,9 +145,9 @@ class BinderSpec extends WordSpecLike with Matchers {
     }
 
     "convert correctly a bytestring in mapping" in {
-      implicit val builder = Json.objectBuilder()
+      implicit val builder: JsObjectBuilder = Json.objectBuilder()
       IntBinder("foobar")(ByteString("1"))
-      builder.result() should equal(Json.obj("foobar" -> JsInt(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsInt.fromLiteral(1)))
     }
 
     "fail to convert a bytestring in mapping" in {
@@ -157,8 +157,8 @@ class BinderSpec extends WordSpecLike with Matchers {
     }
 
     "convert correctly a json value in bytestring" in {
-      implicit val builder = ByteString.newBuilder
-      IntBinder("foobar").applyByteString(Json.obj("foobar" -> JsInt(1)))
+      implicit val builder: ByteStringBuilder = ByteString.newBuilder
+      IntBinder("foobar").applyByteString(Json.obj("foobar" -> JsInt.fromLiteral(1)))
       builder.result() should equal(ByteString("1"))
     }
 
@@ -169,13 +169,13 @@ class BinderSpec extends WordSpecLike with Matchers {
     }
 
     "convert correctly a json value in string" in {
-      implicit val builder = new CharBuilder
-      IntBinder("foobar").applyString(Json.obj("foobar" -> JsInt(1)))
+      implicit val builder: CharBuilder = new CharBuilder
+      IntBinder("foobar").applyString(Json.obj("foobar" -> JsInt.fromLiteral(1)))
       builder.toString should equal("1")
     }
 
     "fail to convert a json value in string" in {
-      implicit val builder = new CharBuilder
+      implicit val builder: CharBuilder = new CharBuilder
       IntBinder("foobar").applyString(Json.obj("foobar" -> "1"))
       builder.toString should equal("")
     }
@@ -186,37 +186,37 @@ class BinderSpec extends WordSpecLike with Matchers {
     "convert correctly a boolean in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       LongBinder("foobar")(true)
-      builder.result() should equal(Json.obj("foobar" -> JsLong(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsLong.fromLiteral(1)))
     }
 
     "convert correctly an int in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       LongBinder("foobar")(1)
-      builder.result() should equal(Json.obj("foobar" -> JsLong(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsLong.fromLiteral(1)))
     }
 
     "convert correctly a long in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       LongBinder("foobar")(1L)
-      builder.result() should equal(Json.obj("foobar" -> JsLong(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsLong.fromLiteral(1)))
     }
 
     "convert correctly a float in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       LongBinder("foobar")(1.0F)
-      builder.result() should equal(Json.obj("foobar" -> JsLong(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsLong.fromLiteral(1)))
     }
 
     "convert correctly a double in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       LongBinder("foobar")(1.0D)
-      builder.result() should equal(Json.obj("foobar" -> JsLong(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsLong.fromLiteral(1)))
     }
 
     "convert correctly a string in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       LongBinder("foobar")("1")
-      builder.result() should equal(Json.obj("foobar" -> JsLong(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsLong.fromLiteral(1)))
     }
 
     "fail to convert a string in mapping" in {
@@ -228,7 +228,7 @@ class BinderSpec extends WordSpecLike with Matchers {
     "convert correctly a bytestring in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       LongBinder("foobar")(ByteString("1"))
-      builder.result() should equal(Json.obj("foobar" -> JsLong(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsLong.fromLiteral(1)))
     }
 
     "fail to convert a bytestring in mapping" in {
@@ -238,25 +238,25 @@ class BinderSpec extends WordSpecLike with Matchers {
     }
 
     "convert correctly a json value in bytestring" in {
-      implicit val builder = ByteString.newBuilder
-      LongBinder("foobar").applyByteString(Json.obj("foobar" -> JsLong(1)))
+      implicit val builder: ByteStringBuilder = ByteString.newBuilder
+      LongBinder("foobar").applyByteString(Json.obj("foobar" -> JsLong.fromLiteral(1)))
       builder.result() should equal(ByteString("1"))
     }
 
     "fail to convert a json value in bytestring" in {
-      implicit val builder = ByteString.newBuilder
+      implicit val builder: ByteStringBuilder = ByteString.newBuilder
       LongBinder("foobar").applyByteString(Json.obj("foobar" -> "1"))
       builder.result() should equal(ByteString.empty)
     }
 
     "convert correctly a json value in string" in {
-      implicit val builder = new CharBuilder
-      LongBinder("foobar").applyString(Json.obj("foobar" -> JsLong(1)))
+      implicit val builder: CharBuilder = new CharBuilder
+      LongBinder("foobar").applyString(Json.obj("foobar" -> JsLong.fromLiteral(1)))
       builder.toString should equal("1")
     }
 
     "fail to convert a json value in string" in {
-      implicit val builder = new CharBuilder
+      implicit val builder: CharBuilder = new CharBuilder
       LongBinder("foobar").applyString(Json.obj("foobar" -> "1"))
       builder.toString should equal("")
     }
@@ -267,37 +267,37 @@ class BinderSpec extends WordSpecLike with Matchers {
     "convert correctly a boolean in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       FloatBinder("foobar")(true)
-      builder.result() should equal(Json.obj("foobar" -> JsFloat(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsFloat.fromLiteral(1)))
     }
 
     "convert correctly an int in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       FloatBinder("foobar")(1)
-      builder.result() should equal(Json.obj("foobar" -> JsFloat(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsFloat.fromLiteral(1)))
     }
 
     "convert correctly a long in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       FloatBinder("foobar")(1L)
-      builder.result() should equal(Json.obj("foobar" -> JsFloat(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsFloat.fromLiteral(1)))
     }
 
     "convert correctly a float in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       FloatBinder("foobar")(1.0F)
-      builder.result() should equal(Json.obj("foobar" -> JsFloat(1.0F)))
+      builder.result() should equal(Json.obj("foobar" -> JsFloat.fromLiteral(1.0F)))
     }
 
     "convert correctly a double in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       FloatBinder("foobar")(1.0D)
-      builder.result() should equal(Json.obj("foobar" -> JsFloat(1.0F)))
+      builder.result() should equal(Json.obj("foobar" -> JsFloat.fromLiteral(1.0F)))
     }
 
     "convert correctly a string in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       FloatBinder("foobar")("1")
-      builder.result() should equal(Json.obj("foobar" -> JsFloat(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsFloat.fromLiteral(1)))
     }
 
     "fail to convert a string in mapping" in {
@@ -309,7 +309,7 @@ class BinderSpec extends WordSpecLike with Matchers {
     "convert correctly a bytestring in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       FloatBinder("foobar")(ByteString("1.0"))
-      builder.result() should equal(Json.obj("foobar" -> JsFloat(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsFloat.fromLiteral(1)))
     }
 
     "fail to convert a bytestring in mapping" in {
@@ -319,25 +319,25 @@ class BinderSpec extends WordSpecLike with Matchers {
     }
 
     "convert correctly a json value in bytestring" in {
-      implicit val builder = ByteString.newBuilder
-      FloatBinder("foobar").applyByteString(Json.obj("foobar" -> JsFloat(1)))
+      implicit val builder: ByteStringBuilder = ByteString.newBuilder
+      FloatBinder("foobar").applyByteString(Json.obj("foobar" -> JsFloat.fromLiteral(1)))
       builder.result() should equal(ByteString("1.0"))
     }
 
     "fail to convert a json value in bytestring" in {
-      implicit val builder = ByteString.newBuilder
+      implicit val builder: ByteStringBuilder = ByteString.newBuilder
       FloatBinder("foobar").applyByteString(Json.obj("foobar" -> "1"))
       builder.result() should equal(ByteString.empty)
     }
 
     "convert correctly a json value in string" in {
-      implicit val builder = new CharBuilder
-      FloatBinder("foobar").applyString(Json.obj("foobar" -> JsFloat(1)))
+      implicit val builder: CharBuilder = new CharBuilder
+      FloatBinder("foobar").applyString(Json.obj("foobar" -> JsFloat.fromLiteral(1)))
       builder.toString should equal("1.0")
     }
 
     "fail to convert a json value in string" in {
-      implicit val builder = new CharBuilder
+      implicit val builder: CharBuilder = new CharBuilder
       FloatBinder("foobar").applyString(Json.obj("foobar" -> "1"))
       builder.toString should equal("")
     }
@@ -348,37 +348,37 @@ class BinderSpec extends WordSpecLike with Matchers {
     "convert correctly a boolean in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       DoubleBinder("foobar")(true)
-      builder.result() should equal(Json.obj("foobar" -> JsDouble(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsDouble.fromLiteral(1)))
     }
 
     "convert correctly an int in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       DoubleBinder("foobar")(1)
-      builder.result() should equal(Json.obj("foobar" -> JsDouble(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsDouble.fromLiteral(1)))
     }
 
     "convert correctly a long in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       DoubleBinder("foobar")(1L)
-      builder.result() should equal(Json.obj("foobar" -> JsDouble(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsDouble.fromLiteral(1)))
     }
 
     "convert correctly a float in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       DoubleBinder("foobar")(1.0F)
-      builder.result() should equal(Json.obj("foobar" -> JsDouble(1.0F)))
+      builder.result() should equal(Json.obj("foobar" -> JsDouble.fromLiteral(1.0F)))
     }
 
     "convert correctly a double in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       DoubleBinder("foobar")(1.0D)
-      builder.result() should equal(Json.obj("foobar" -> JsDouble(1.0F)))
+      builder.result() should equal(Json.obj("foobar" -> JsDouble.fromLiteral(1.0F)))
     }
 
     "convert correctly a string in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       DoubleBinder("foobar")("1.0")
-      builder.result() should equal(Json.obj("foobar" -> JsDouble(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsDouble.fromLiteral(1)))
     }
 
     "fail to convert a string in mapping" in {
@@ -390,7 +390,7 @@ class BinderSpec extends WordSpecLike with Matchers {
     "convert correctly a bytestring in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       DoubleBinder("foobar")(ByteString("1"))
-      builder.result() should equal(Json.obj("foobar" -> JsDouble(1)))
+      builder.result() should equal(Json.obj("foobar" -> JsDouble.fromLiteral(1)))
     }
 
     "fail to convert a bytestring in mapping" in {
@@ -400,25 +400,25 @@ class BinderSpec extends WordSpecLike with Matchers {
     }
 
     "convert correctly a json value in bytestring" in {
-      implicit val builder = ByteString.newBuilder
-      DoubleBinder("foobar").applyByteString(Json.obj("foobar" -> JsDouble(1)))
+      implicit val builder: ByteStringBuilder = ByteString.newBuilder
+      DoubleBinder("foobar").applyByteString(Json.obj("foobar" -> JsDouble.fromLiteral(1)))
       builder.result() should equal(ByteString("1.0"))
     }
 
     "fail to convert a json value in bytestring" in {
-      implicit val builder = ByteString.newBuilder
+      implicit val builder: ByteStringBuilder = ByteString.newBuilder
       DoubleBinder("foobar").applyByteString(Json.obj("foobar" -> "1"))
       builder.result() should equal(ByteString.empty)
     }
 
     "convert correctly a json value in string" in {
-      implicit val builder = new CharBuilder
-      DoubleBinder("foobar").applyString(Json.obj("foobar" -> JsDouble(1)))
+      implicit val builder: CharBuilder = new CharBuilder
+      DoubleBinder("foobar").applyString(Json.obj("foobar" -> JsDouble.fromLiteral(1)))
       builder.toString should equal("1.0")
     }
 
     "fail to convert a json value in string" in {
-      implicit val builder = new CharBuilder
+      implicit val builder: CharBuilder = new CharBuilder
       DoubleBinder("foobar").applyString(Json.obj("foobar" -> "1"))
       builder.toString should equal("")
     }
@@ -429,65 +429,65 @@ class BinderSpec extends WordSpecLike with Matchers {
     "convert correctly a boolean in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       BytesBinder("foobar")(true)
-      builder.result() should equal(Json.obj("foobar" -> JsBytes(ByteString("true"))))
+      builder.result() should equal(Json.obj("foobar" -> JsBytes.fromLiteral(ByteString("true"))))
     }
 
     "convert correctly an int in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       BytesBinder("foobar")(1)
-      builder.result() should equal(Json.obj("foobar" -> JsBytes(ByteString("1"))))
+      builder.result() should equal(Json.obj("foobar" -> JsBytes.fromLiteral(ByteString("1"))))
     }
 
     "convert correctly a long in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       BytesBinder("foobar")(1L)
-      builder.result() should equal(Json.obj("foobar" -> JsBytes(ByteString("1"))))
+      builder.result() should equal(Json.obj("foobar" -> JsBytes.fromLiteral(ByteString("1"))))
     }
 
     "convert correctly a float in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       BytesBinder("foobar")(1.0F)
-      builder.result() should equal(Json.obj("foobar" -> JsBytes(ByteString("1.0"))))
+      builder.result() should equal(Json.obj("foobar" -> JsBytes.fromLiteral(ByteString("1.0"))))
     }
 
     "convert correctly a double in mapping" in {
-      implicit val builder = Json.objectBuilder()
+      implicit val builder: JsObjectBuilder = Json.objectBuilder()
       BytesBinder("foobar")(1.0D)
-      builder.result() should equal(Json.obj("foobar" -> JsBytes(ByteString("1.0"))))
+      builder.result() should equal(Json.obj("foobar" -> JsBytes.fromLiteral(ByteString("1.0"))))
     }
 
     "convert correctly a string in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       BytesBinder("foobar")("test")
-      builder.result() should equal(Json.obj("foobar" -> JsBytes(ByteString("test"))))
+      builder.result() should equal(Json.obj("foobar" -> JsBytes.fromLiteral(ByteString("test"))))
     }
 
     "convert correctly a bytestring in mapping" in {
       implicit val builder: JsObjectBuilder = Json.objectBuilder()
       BytesBinder("foobar")(ByteString("test"))
-      builder.result() should equal(Json.obj("foobar" -> JsBytes(ByteString("test"))))
+      builder.result() should equal(Json.obj("foobar" -> JsBytes.fromLiteral(ByteString("test"))))
     }
 
     "convert correctly a json value in bytestring" in {
-      implicit val builder = ByteString.newBuilder
-      BytesBinder("foobar").applyByteString(Json.obj("foobar" -> JsBytes(ByteString("test"))))
+      implicit val builder: ByteStringBuilder = ByteString.newBuilder
+      BytesBinder("foobar").applyByteString(Json.obj("foobar" -> JsBytes.fromLiteral(ByteString("test"))))
       builder.result() should equal(ByteString("test"))
     }
 
     "fail to convert a json value in bytestring" in {
-      implicit val builder = ByteString.newBuilder
+      implicit val builder: ByteStringBuilder = ByteString.newBuilder
       BytesBinder("foobar").applyByteString(Json.obj("foobar" -> "1"))
       builder.result() should equal(ByteString.empty)
     }
 
     "convert correctly a json value in string" in {
-      implicit val builder = new CharBuilder
-      BytesBinder("foobar").applyString(Json.obj("foobar" -> JsBytes(ByteString("test"))))
+      implicit val builder: CharBuilder = new CharBuilder
+      BytesBinder("foobar").applyString(Json.obj("foobar" -> JsBytes.fromLiteral(ByteString("test"))))
       builder.toString should equal("test")
     }
 
     "fail to convert a json value in string" in {
-      implicit val builder = new CharBuilder
+      implicit val builder: CharBuilder = new CharBuilder
       BytesBinder("foobar").applyString(Json.obj("foobar" -> "1"))
       builder.toString should equal("")
     }

--- a/core/src/test/scala/io/techcode/streamy/util/json/JsonImplicitSpec.scala
+++ b/core/src/test/scala/io/techcode/streamy/util/json/JsonImplicitSpec.scala
@@ -50,31 +50,31 @@ class JsonImplicitSpec extends WordSpecLike with Matchers {
     }
 
     "provide a shortcut to convert string in json" in {
-      stringToJson("""{"test":"test"}""") should equal(JsString("""{"test":"test"}"""))
+      stringToJson("""{"test":"test"}""") should equal(JsString.fromLiteral("""{"test":"test"}"""))
     }
 
     "provide a shortcut to convert float in json" in {
-      floatToJson(2.0F) should equal(JsFloat(2.0F))
+      floatToJson(2.0F) should equal(JsFloat.fromLiteral(2.0F))
     }
 
     "provide a shortcut to convert double in json" in {
-      doubleToJson(2.0D) should equal(JsDouble(2.0D))
+      doubleToJson(2.0D) should equal(JsDouble.fromLiteral(2.0D))
     }
 
     "provide a shortcut to convert byte in json" in {
-      byteToJson(2) should equal(JsInt(2))
+      byteToJson(2) should equal(JsInt.fromLiteral(2))
     }
 
     "provide a shortcut to convert short in json" in {
-      shortToJson(2) should equal(JsInt(2))
+      shortToJson(2) should equal(JsInt.fromLiteral(2))
     }
 
     "provide a shortcut to convert int in json" in {
-      intToJson(2) should equal(JsInt(2))
+      intToJson(2) should equal(JsInt.fromLiteral(2))
     }
 
     "provide a shortcut to convert long in json" in {
-      longToJson(2L) should equal(JsLong(2L))
+      longToJson(2L) should equal(JsLong.fromLiteral(2L))
     }
 
     "provide a shortcut to convert boolean in json" in {
@@ -82,11 +82,11 @@ class JsonImplicitSpec extends WordSpecLike with Matchers {
     }
 
     "provide a shortcut to convert byte string in json" in {
-      byteStringToJson(ByteString.empty) should equal(JsBytes(ByteString.empty))
+      byteStringToJson(ByteString.empty) should equal(JsBytes.fromLiteral(ByteString.empty))
     }
 
     "provide a shortcut to convert big decimal in json" in {
-      bigDecimalToJson(BigDecimal.valueOf(0)) should equal(JsBigDecimal(BigDecimal.valueOf(0)))
+      bigDecimalToJson(BigDecimal.valueOf(0)) should equal(JsBigDecimal.fromLiteral(BigDecimal.valueOf(0)))
     }
   }
 

--- a/core/src/test/scala/io/techcode/streamy/util/json/JsonOperationSpec.scala
+++ b/core/src/test/scala/io/techcode/streamy/util/json/JsonOperationSpec.scala
@@ -192,25 +192,25 @@ class JsonOperationSpec extends WordSpecLike with Matchers {
   "Json test operation" should {
     "return JsUndefined on failure" in {
       val input = Json.obj("test" -> "test")
-      val result = input.patch(Test(Root / "test", JsInt(0)))
+      val result = input.patch(Test(Root / "test", JsInt.fromLiteral(0)))
       result should equal(JsUndefined)
     }
 
     "return current value on success" in {
       val input = Json.obj("test" -> "test")
-      val result = input.patch(Test(Root / "test", JsString("test")))
+      val result = input.patch(Test(Root / "test", JsString.fromLiteral("test")))
       result should equal(input)
     }
 
     "return JsUndefined on deep failure" in {
       val input = Json.obj("test" -> Json.obj("test" -> "failure"))
-      val result = input.patch(Test(Root / "test" / "test", JsInt(0)))
+      val result = input.patch(Test(Root / "test" / "test", JsInt.fromLiteral(0)))
       result should equal(JsUndefined)
     }
 
     "return JsUndefined on missing" in {
       val input = Json.obj("test" -> "test")
-      val result = input.patch(Test(Root / "failure", JsInt(0)))
+      val result = input.patch(Test(Root / "failure", JsInt.fromLiteral(0)))
       result should equal(JsUndefined)
     }
   }

--- a/core/src/test/scala/io/techcode/streamy/util/json/JsonParserSpec.scala
+++ b/core/src/test/scala/io/techcode/streamy/util/json/JsonParserSpec.scala
@@ -48,56 +48,56 @@ class JsonParserSpec extends WordSpecLike with Matchers {
     }
 
     "parse an json int zero correctly" in {
-      Json.parseByteStringUnsafe(ByteString("0")) should equal(JsInt(0))
+      Json.parseByteStringUnsafe(ByteString("0")) should equal(JsInt.fromLiteral(0))
     }
 
     "parse an json int correctly" in {
-      Json.parseByteStringUnsafe(ByteString(Int.MinValue.toString)) should equal(JsInt(Int.MinValue))
+      Json.parseByteStringUnsafe(ByteString("-12345678")) should equal(JsInt.fromLiteral(-12345678))
     }
 
     "parse an json long correctly" in {
-      Json.parseByteStringUnsafe(ByteString(Long.MinValue.toString)) should equal(JsLong(Long.MinValue))
+      Json.parseByteStringUnsafe(ByteString(Long.MinValue.toString)) should equal(JsLong.fromLiteral(Long.MinValue))
     }
 
     "parse an json float correctly" in {
-      Json.parseByteStringUnsafe(ByteString(Float.MinValue.toString)) should equal(JsBigDecimal(BigDecimal(Float.MinValue.toString)))
+      Json.parseByteStringUnsafe(ByteString(Float.MinValue.toString)) should equal(JsBigDecimal.fromLiteral(BigDecimal(Float.MinValue.toString)))
     }
 
     "parse an json float 1.23 correctly" in {
-      Json.parseByteStringUnsafe(ByteString("1.23")) should equal(JsBigDecimal(BigDecimal("1.23")))
+      Json.parseByteStringUnsafe(ByteString("1.23")) should equal(JsBigDecimal.fromLiteral(BigDecimal("1.23")))
     }
 
     "parse an json double correctly" in {
-      Json.parseByteStringUnsafe(ByteString(Double.MinValue.toString)) should equal(JsBigDecimal(BigDecimal(Double.MinValue.toString)))
+      Json.parseByteStringUnsafe(ByteString(Double.MinValue.toString)) should equal(JsBigDecimal.fromLiteral(BigDecimal(Double.MinValue.toString)))
     }
 
     "parse an json big decimal correctly" in {
-      Json.parseByteStringUnsafe(ByteString("1e20")) should equal(JsBigDecimal(BigDecimal("1e20")))
+      Json.parseByteStringUnsafe(ByteString("1e20")) should equal(JsBigDecimal.fromLiteral(BigDecimal("1e20")))
     }
 
     "parse an json big decimal -1E10 correctly" in {
-      Json.parseByteStringUnsafe(ByteString("-1E10")) should equal(JsBigDecimal(BigDecimal("-1E10")))
+      Json.parseByteStringUnsafe(ByteString("-1E10")) should equal(JsBigDecimal.fromLiteral(BigDecimal("-1E10")))
     }
 
     "parse an json big decimal 12.34e-10 correctly" in {
-      Json.parseByteStringUnsafe(ByteString("12.34e-10")) should equal(JsBigDecimal(BigDecimal("1.234E-9")))
+      Json.parseByteStringUnsafe(ByteString("12.34e-10")) should equal(JsBigDecimal.fromLiteral(BigDecimal("1.234E-9")))
     }
 
     "parse an json string correctly" in {
-      Json.parseByteStringUnsafe(ByteString(""""foobar"""")) should equal(JsString("foobar"))
+      Json.parseByteStringUnsafe(ByteString(""""foobar"""")) should equal(JsString.fromLiteral("foobar"))
     }
 
     "parse an json string from encoded bytes correctly" in {
-      Json.parseByteStringUnsafe(ByteString("\"4-byte UTF-8 chars like \uD801\uDC37\"")) should equal(JsString("4-byte UTF-8 chars like \uD801\uDC37"))
+      Json.parseByteStringUnsafe(ByteString("\"4-byte UTF-8 chars like \uD801\uDC37\"")) should equal(JsString.fromLiteral("4-byte UTF-8 chars like \uD801\uDC37"))
     }
 
     "parse an json string escape correctly" in {
-      Json.parseByteStringUnsafe(ByteString(""""\"\\/\b\f\n\r\t"""")) should equal(JsString("\"\\/\b\f\n\r\t"))
-      Json.parseByteStringUnsafe(ByteString("\"L\\" + "u00e4nder\"")) should equal(JsString("Länder"))
+      Json.parseByteStringUnsafe(ByteString(""""\"\\/\b\f\n\r\t"""")) should equal(JsString.fromLiteral("\"\\/\b\f\n\r\t"))
+      Json.parseByteStringUnsafe(ByteString("\"L\\" + "u00e4nder\"")) should equal(JsString.fromLiteral("Länder"))
     }
 
     "parse an json string of the slash (SOLIDUS) character correctly" in {
-      Json.parseByteStringUnsafe(ByteString("\"" + "/\\/\\u002f" + "\"")) should equal(JsString("///"))
+      Json.parseByteStringUnsafe(ByteString("\"" + "/\\/\\u002f" + "\"")) should equal(JsString.fromLiteral("///"))
     }
 
     "parse a json object correctly" in {
@@ -115,7 +115,7 @@ class JsonParserSpec extends WordSpecLike with Matchers {
         """[null, 1.23, {"key":true }]"""
       )) should equal(Json.arr(
         JsNull,
-        JsBigDecimal(BigDecimal("1.23")),
+        JsBigDecimal.fromLiteral(BigDecimal("1.23")),
         Json.obj("key" -> JsTrue)
       ))
     }
@@ -131,7 +131,7 @@ class JsonParserSpec extends WordSpecLike with Matchers {
     }
 
     "parse directly from UTF-8 encoded bytes when string starts with a multi-byte character" in {
-      Json.parseByteStringUnsafe(ByteString(""""£0.99"""")) should equal(JsString("£0.99"))
+      Json.parseByteStringUnsafe(ByteString(""""£0.99"""")) should equal(JsString.fromLiteral("£0.99"))
     }
 
     "parse a json object with whitespace correctly" in {

--- a/core/src/test/scala/io/techcode/streamy/util/json/JsonPointerSpec.scala
+++ b/core/src/test/scala/io/techcode/streamy/util/json/JsonPointerSpec.scala
@@ -38,12 +38,12 @@ class JsPointerSpec extends WordSpecLike with Matchers {
 
     "return a value if possible when evaluate on json object" in {
       val input = Json.obj("test" -> "foobar")
-      input.evaluate(Root / "test") should equal(JsString("foobar"))
+      input.evaluate(Root / "test") should equal(JsString.fromLiteral("foobar"))
     }
 
     "return a value if possible when evaluate on deep json object" in {
       val input = Json.obj("test" -> Json.arr(Json.obj("test" -> "foobar")))
-      input.evaluate(Root / "test" / 0 / "test") should equal(JsString("foobar"))
+      input.evaluate(Root / "test" / 0 / "test") should equal(JsString.fromLiteral("foobar"))
     }
 
     "return a none when evaluate on json object is failed" in {
@@ -58,13 +58,13 @@ class JsPointerSpec extends WordSpecLike with Matchers {
 
     "return a value if possible when evaluate on json array" in {
       val input = Json.arr("test", "foobar")
-      input.evaluate(Root / 0) should equal(JsString("test"))
-      input.evaluate(Root / 1) should equal(JsString("foobar"))
+      input.evaluate(Root / 0) should equal(JsString.fromLiteral("test"))
+      input.evaluate(Root / 1) should equal(JsString.fromLiteral("foobar"))
     }
 
     "return a value if possible when evaluate on deep json array" in {
       val input = Json.obj("test" -> Json.obj("test" -> Json.arr("foobar")))
-      input.evaluate(Root / "test" / "test" / 0) should equal(JsString("foobar"))
+      input.evaluate(Root / "test" / "test" / 0) should equal(JsString.fromLiteral("foobar"))
     }
 
     "return a none when evaluate on json array is failed" in {

--- a/core/src/test/scala/io/techcode/streamy/util/json/JsonPointerSpec.scala
+++ b/core/src/test/scala/io/techcode/streamy/util/json/JsonPointerSpec.scala
@@ -23,12 +23,13 @@
  */
 package io.techcode.streamy.util.json
 
+import io.techcode.streamy.util.parser.ParseException
 import org.scalatest._
 
 /**
   * JsonPointer spec.
   */
-class JsPointerSpec extends WordSpecLike with Matchers {
+class JsonPointerSpec extends WordSpecLike with Matchers {
 
   "JsonPointer" should {
     "return same json value for root pointer" in {
@@ -78,7 +79,12 @@ class JsPointerSpec extends WordSpecLike with Matchers {
     }
 
     "return a string representation" in {
-      (Root / "failed").toString should equal("/failed")
+      (Root / "failed" / 0).toString should equal("/failed/0")
+    }
+
+    "return if this is a root json pointer" in {
+      Root.isRoot should equal(true)
+      (Root / "foobar").isRoot should equal(false)
     }
 
     "equal to the same root json pointer" in {
@@ -90,7 +96,7 @@ class JsPointerSpec extends WordSpecLike with Matchers {
     }
 
     "not equal to the same json pointer" in {
-      Root / "foobar" should not equal("foobar")
+      Root / "foobar" should not equal(Root / "foo" / "bar")
     }
 
     "be iterable" in {
@@ -98,7 +104,7 @@ class JsPointerSpec extends WordSpecLike with Matchers {
     }
   }
 
-  "JsonObjectAccessor" should {
+  "JsObjectAccessor" should {
     "be equal to the same accessor" in {
       JsObjectAccessor("foobar") should equal(JsObjectAccessor("foobar"))
     }
@@ -112,7 +118,7 @@ class JsPointerSpec extends WordSpecLike with Matchers {
     }
   }
 
-  "JsonArrayAccessor" should {
+  "JsArrayAccessor" should {
     "be equal to the same accessor" in {
       JsArrayAccessor(0) should equal(JsArrayAccessor(0))
     }
@@ -128,49 +134,46 @@ class JsPointerSpec extends WordSpecLike with Matchers {
 
   "JsonPointer parser" should {
     "parse correctly a root pointer" in {
-      val parser = new JsonPointerParser()
-      parser.parse("/") should equal(Right(Root))
+      JsonPointerParser.parseUnsafe("/") should equal(Root)
     }
 
     "parse correctly a simple key pointer" in {
-      val parser = new JsonPointerParser()
-      parser.parse("/key") should equal(Right(Root / "key"))
+      JsonPointerParser.parseUnsafe("/key") should equal(Root / "key")
     }
 
     "parse correctly a simple key pointer with escaped character" in {
-      val parser = new JsonPointerParser()
-      parser.parse("/key~0~1") should equal(Right(Root / "key~/"))
+      JsonPointerParser.parseUnsafe("/key~0~1") should equal(Root / "key~/")
     }
 
     "parse correctly a simple indice pointer with character" in {
-      val parser = new JsonPointerParser()
-      parser.parse("/0") should equal(Right(Root / 0))
+      JsonPointerParser.parseUnsafe("/0") should equal(Root / 0)
     }
 
     "parse correctly a simple indice pointer with escaped character" in {
-      val parser = new JsonPointerParser()
-      parser.parse("/0/~0~1") should equal(Right(Root / 0 / "~/"))
+      JsonPointerParser.parseUnsafe("/0/~0~1") should equal(Root / 0 / "~/")
     }
 
     "parse correctly a complex pointer" in {
-      val parser = new JsonPointerParser()
-      parser.parse("/0/key/1") should equal(Right(Root / 0 / "key" / 1))
+      JsonPointerParser.parseUnsafe("/0/key/1") should equal(Root / 0 / "key" / 1)
     }
 
     "parse correctly a complex pointer with escaped character" in {
-      val parser = new JsonPointerParser()
-      parser.parse("/0/key/1/~0~1") should equal(Right(Root / 0 / "key" / 1 / "~/"))
+      JsonPointerParser.parseUnsafe("/0/key/1/~0~1") should equal(Root / 0 / "key" / 1 / "~/")
     }
 
     "parse correctly a multiples pointers" in {
-      val parser = new JsonPointerParser()
-      parser.parse("/key") should equal(Right(Root / "key"))
-      parser.parse("/foobar") should equal(Right(Root / "foobar"))
+      JsonPointerParser.parseUnsafe("/key") should equal(Root / "key")
+      JsonPointerParser.parseUnsafe("/foobar") should equal(Root / "foobar")
     }
 
     "fail correctly for an invalid json pointer" in {
-      val parser = new JsonPointerParser()
-      parser.parse("key").isLeft should equal(true)
+      JsonPointerParser.parse("key").isLeft should equal(true)
+    }
+
+    "fail correctly for an unsafe invalid json pointer" in {
+      assertThrows[ParseException] {
+        JsonPointerParser.parseUnsafe("key")
+      }
     }
   }
 

--- a/core/src/test/scala/io/techcode/streamy/util/json/JsonPrinterSpec.scala
+++ b/core/src/test/scala/io/techcode/streamy/util/json/JsonPrinterSpec.scala
@@ -44,44 +44,104 @@ class JsonPrinterSpec extends WordSpecLike with Matchers {
       Json.printStringUnsafe(JsNull) should equal("null")
     }
 
-    "print an json int correctly" in {
+    "print an json int literal correctly" in {
       Json.printStringUnsafe(JsInt.fromLiteral(Int.MinValue)) should equal(Int.MinValue.toString)
     }
 
-    "print an json long correctly" in {
+    "print an json int string representation correctly" in {
+      Json.printStringUnsafe(JsInt.fromStringUnsafe(Int.MinValue.toString)) should equal(Int.MinValue.toString)
+    }
+
+    "print an json int bytes representation correctly" in {
+      Json.printStringUnsafe(JsInt.fromByteStringUnsafe(ByteString(Int.MinValue.toString))) should equal(Int.MinValue.toString)
+    }
+
+    "print an json long literal correctly" in {
       Json.printStringUnsafe(JsLong.fromLiteral(Long.MinValue)) should equal(Long.MinValue.toString)
     }
 
-    "print an json float correctly" in {
+    "print an json long string representation correctly" in {
+      Json.printStringUnsafe(JsLong.fromStringUnsafe(Long.MinValue.toString)) should equal(Long.MinValue.toString)
+    }
+
+    "print an json long bytes representation correctly" in {
+      Json.printStringUnsafe(JsLong.fromByteStringUnsafe(ByteString(Long.MinValue.toString))) should equal(Long.MinValue.toString)
+    }
+
+    "print an json float literal correctly" in {
       Json.printStringUnsafe(JsFloat.fromLiteral(Float.MinValue)) should equal(Float.MinValue.toString)
     }
 
-    "print an json double correctly" in {
+    "print an json float string representation correctly" in {
+      Json.printStringUnsafe(JsFloat.fromStringUnsafe(Float.MinValue.toString)) should equal(Float.MinValue.toString)
+    }
+
+    "print an json float bytes representation correctly" in {
+      Json.printStringUnsafe(JsFloat.fromByteStringUnsafe(ByteString(Float.MinValue.toString))) should equal(Float.MinValue.toString)
+    }
+
+    "print an json double literal correctly" in {
       Json.printStringUnsafe(JsDouble.fromLiteral(Double.MinValue)) should equal(Double.MinValue.toString)
     }
 
-    "print an json big decimal correctly" in {
+    "print an json double string representation correctly" in {
+      Json.printStringUnsafe(JsDouble.fromStringUnsafe(Double.MinValue.toString)) should equal(Double.MinValue.toString)
+    }
+
+    "print an json double bytes representation correctly" in {
+      Json.printStringUnsafe(JsDouble.fromByteStringUnsafe(ByteString(Double.MinValue.toString))) should equal(Double.MinValue.toString)
+    }
+
+    "print an json big decimal literal correctly" in {
       Json.printStringUnsafe(JsBigDecimal.fromLiteral(BigDecimal("1e20"))) should equal("1E+20")
     }
 
-    "print an json bytes correctly" in {
+    "print an json big decimal string representation correctly" in {
+      Json.printStringUnsafe(JsBigDecimal.fromStringUnsafe(BigDecimal("1e20").toString())) should equal("1E+20")
+    }
+
+    "print an json big decimal bytes representation correctly" in {
+      Json.printStringUnsafe(JsBigDecimal.fromByteStringUnsafe(ByteString(BigDecimal("1e20").toString()))) should equal("1E+20")
+    }
+
+    "print an json bytes literal correctly" in {
       Json.printStringUnsafe(JsBytes.fromLiteral(ByteString("foobar"))) should equal("\"Zm9vYmFy\"")
     }
 
-    "print an json string without unicode char correctly" in {
+    "print an json bytes string representation correctly" in {
+      Json.printStringUnsafe(JsBytes.fromStringUnsafe("foobar")) should equal("\"Zm9vYmFy\"")
+    }
+
+    "print an json string literal without unicode char correctly" in {
       Json.printStringUnsafe(JsString.fromLiteral("foobar")) should equal("\"foobar\"")
     }
 
-    "print an json string with \" char correctly" in {
+    "print an json string literal with \" char correctly" in {
       Json.printStringUnsafe(JsString.fromLiteral("foob\"ar")) should equal(""""foob\"ar"""")
     }
 
-    "print an json string with \\ char correctly" in {
+    "print an json string literal with \\ char correctly" in {
       Json.printStringUnsafe(JsString.fromLiteral("foob\\\\ar")) should equal(""""foob\\\\ar"""")
     }
 
-    "print an json string with control chars correctly" in {
+    "print an json string literal with control chars correctly" in {
       Json.printStringUnsafe(JsString.fromLiteral("\b\f\n\r\t")) should equal(""""\b\f\n\r\t"""")
+    }
+
+    "print an json string bytes representation without unicode char correctly" in {
+      Json.printStringUnsafe(JsString.fromByteStringUnsafe(ByteString("foobar"))) should equal("\"foobar\"")
+    }
+
+    "print an json string bytes representation with \" char correctly" in {
+      Json.printStringUnsafe(JsString.fromByteStringUnsafe(ByteString("foob\"ar"))) should equal(""""foob\"ar"""")
+    }
+
+    "print an json string bytes representation with \\ char correctly" in {
+      Json.printStringUnsafe(JsString.fromByteStringUnsafe(ByteString("foob\\\\ar"))) should equal(""""foob\\\\ar"""")
+    }
+
+    "print an json string bytes representation with control chars correctly" in {
+      Json.printStringUnsafe(JsString.fromByteStringUnsafe(ByteString("\b\f\n\r\t"))) should equal(""""\b\f\n\r\t"""")
     }
 
   }

--- a/core/src/test/scala/io/techcode/streamy/util/json/JsonPrinterSpec.scala
+++ b/core/src/test/scala/io/techcode/streamy/util/json/JsonPrinterSpec.scala
@@ -45,43 +45,43 @@ class JsonPrinterSpec extends WordSpecLike with Matchers {
     }
 
     "print an json int correctly" in {
-      Json.printStringUnsafe(JsInt(Int.MinValue)) should equal(Int.MinValue.toString)
+      Json.printStringUnsafe(JsInt.fromLiteral(Int.MinValue)) should equal(Int.MinValue.toString)
     }
 
     "print an json long correctly" in {
-      Json.printStringUnsafe(JsLong(Long.MinValue)) should equal(Long.MinValue.toString)
+      Json.printStringUnsafe(JsLong.fromLiteral(Long.MinValue)) should equal(Long.MinValue.toString)
     }
 
     "print an json float correctly" in {
-      Json.printStringUnsafe(JsFloat(Float.MinValue)) should equal(Float.MinValue.toString)
+      Json.printStringUnsafe(JsFloat.fromLiteral(Float.MinValue)) should equal(Float.MinValue.toString)
     }
 
     "print an json double correctly" in {
-      Json.printStringUnsafe(JsDouble(Double.MinValue)) should equal(Double.MinValue.toString)
+      Json.printStringUnsafe(JsDouble.fromLiteral(Double.MinValue)) should equal(Double.MinValue.toString)
     }
 
     "print an json big decimal correctly" in {
-      Json.printStringUnsafe(JsBigDecimal(BigDecimal("1e20"))) should equal("1E+20")
+      Json.printStringUnsafe(JsBigDecimal.fromLiteral(BigDecimal("1e20"))) should equal("1E+20")
     }
 
     "print an json bytes correctly" in {
-      Json.printStringUnsafe(JsBytes(ByteString("foobar"))) should equal("\"Zm9vYmFy\"")
+      Json.printStringUnsafe(JsBytes.fromLiteral(ByteString("foobar"))) should equal("\"Zm9vYmFy\"")
     }
 
     "print an json string without unicode char correctly" in {
-      Json.printStringUnsafe(JsString("foobar")) should equal("\"foobar\"")
+      Json.printStringUnsafe(JsString.fromLiteral("foobar")) should equal("\"foobar\"")
     }
 
     "print an json string with \" char correctly" in {
-      Json.printStringUnsafe(JsString("foob\"ar")) should equal(""""foob\"ar"""")
+      Json.printStringUnsafe(JsString.fromLiteral("foob\"ar")) should equal(""""foob\"ar"""")
     }
 
     "print an json string with \\ char correctly" in {
-      Json.printStringUnsafe(JsString("foob\\\\ar")) should equal(""""foob\\\\ar"""")
+      Json.printStringUnsafe(JsString.fromLiteral("foob\\\\ar")) should equal(""""foob\\\\ar"""")
     }
 
     "print an json string with control chars correctly" in {
-      Json.printStringUnsafe(JsString("\b\f\n\r\t")) should equal(""""\b\f\n\r\t"""")
+      Json.printStringUnsafe(JsString.fromLiteral("\b\f\n\r\t")) should equal(""""\b\f\n\r\t"""")
     }
 
   }

--- a/core/src/test/scala/io/techcode/streamy/util/json/JsonSpec.scala
+++ b/core/src/test/scala/io/techcode/streamy/util/json/JsonSpec.scala
@@ -77,16 +77,16 @@ class JsonSpec extends WordSpecLike with Matchers {
 
     "be iterate using a foreach" in {
       var founded = false
-      Json.obj("test" -> "test").foreach(el => founded |= el._2.equals(JsString("test")))
+      Json.obj("test" -> "test").foreach(el => founded |= el._2.equals(JsString.fromLiteral("test")))
       founded should equal(true)
     }
 
     "return field set" in {
-      Json.obj("test" -> "test").fieldSet should equal(Set("test" -> JsString("test")))
+      Json.obj("test" -> "test").fieldSet should equal(Set("test" -> JsString.fromLiteral("test")))
     }
 
     "return values as iterable" in {
-      Json.obj("test" -> "test").values.head should equal(Seq(JsString("test")).head)
+      Json.obj("test" -> "test").values.head should equal(Seq(JsString.fromLiteral("test")).head)
     }
 
     "flatten correctly a json object" in {
@@ -171,7 +171,7 @@ class JsonSpec extends WordSpecLike with Matchers {
 
     "return value if present" in {
       val input = Json.obj("test" -> "foobar")
-      input("test") should equal(JsString("foobar"))
+      input("test") should equal(JsString.fromLiteral("foobar"))
     }
 
     "return undefined if absent" in {
@@ -354,11 +354,11 @@ class JsonSpec extends WordSpecLike with Matchers {
     }
 
     "be converted to iterator" in {
-      Json.arr("foobar").iterator.next() should equal(JsString("foobar"))
+      Json.arr("foobar").iterator.next() should equal(JsString.fromLiteral("foobar"))
     }
 
     "be converted to seq" in {
-      Json.arr("foobar").toSeq.head should equal(JsString("foobar"))
+      Json.arr("foobar").toSeq.head should equal(JsString.fromLiteral("foobar"))
     }
 
     "map json array correctly" in {
@@ -368,7 +368,7 @@ class JsonSpec extends WordSpecLike with Matchers {
 
     "return value if present" in {
       val input = Json.arr("test", "foobar")
-      input(1) should equal(JsString("foobar"))
+      input(1) should equal(JsString.fromLiteral("foobar"))
     }
 
     "return undefined if absent" in {
@@ -386,7 +386,7 @@ class JsonSpec extends WordSpecLike with Matchers {
 
     "return head of json array if present" in {
       val input = Json.arr("test", "foobar")
-      input.head() should equal(JsString("test"))
+      input.head() should equal(JsString.fromLiteral("test"))
     }
 
     "return head of json array if not present" in {
@@ -396,7 +396,7 @@ class JsonSpec extends WordSpecLike with Matchers {
 
     "return last of json array if present" in {
       val input = Json.arr("test", "foobar")
-      input.last() should equal(JsString("foobar"))
+      input.last() should equal(JsString.fromLiteral("foobar"))
     }
 
     "return last of json array if not present" in {
@@ -431,174 +431,174 @@ class JsonSpec extends WordSpecLike with Matchers {
 
   "Json number" should {
     "stringify float correctly" in {
-      JsFloat(1.0F).toString should equal("1.0")
+      JsFloat.fromLiteral(1.0F).toString should equal("1.0")
     }
 
     "map json number correctly" in {
-      JsFloat(10F).map[JsNumber](_ => JsNull) should equal(JsNull)
+      JsFloat.fromLiteral(10F).map[JsNumber](_ => JsNull) should equal(JsNull)
       JsNull.map[Float](_ => JsNull) should equal(JsUndefined)
     }
 
     "flatMap json number correctly" in {
-      JsFloat(10F).flatMap[JsNumber](_ => JsNull) should equal(JsNull)
+      JsFloat.fromLiteral(10F).flatMap[JsNumber](_ => JsNull) should equal(JsNull)
       JsNull.flatMap[JsNumber](_ => JsNull) should equal(JsUndefined)
     }
 
     "get json number correctly" in {
-      JsFloat(10F).get[JsNumber] should equal(JsFloat(10F))
+      JsFloat.fromLiteral(10F).get[JsNumber] should equal(JsFloat.fromLiteral(10F))
     }
 
     "getOrElse json number correctly" in {
-      JsFloat(10F).getOrElse[JsNumber](JsFloat(0F)) should equal(JsFloat(10F))
-      JsNull.getOrElse[JsNumber](JsFloat(0F)) should equal(JsFloat(0F))
+      JsFloat.fromLiteral(10F).getOrElse[JsNumber](JsFloat.fromLiteral(0F)) should equal(JsFloat.fromLiteral(10F))
+      JsNull.getOrElse[JsNumber](JsFloat.fromLiteral(0F)) should equal(JsFloat.fromLiteral(0F))
     }
 
     "be identified as number" in {
-      JsFloat(0F).isNumber should equal(true)
+      JsFloat.fromLiteral(0F).isNumber should equal(true)
     }
 
     "be identified as not null" in {
-      JsFloat(0F).isNull should equal(false)
+      JsFloat.fromLiteral(0F).isNull should equal(false)
     }
   }
 
   "Json float" should {
     "stringify float correctly" in {
-      JsFloat(1.0F).toString should equal("1.0")
+      JsFloat.fromLiteral(1.0F).toString should equal("1.0")
     }
 
     "map json float correctly" in {
-      JsFloat(10F).map[Float](_ => JsNull) should equal(JsNull)
+      JsFloat.fromLiteral(10F).map[Float](_ => JsNull) should equal(JsNull)
       JsNull.map[Float](_ => JsNull) should equal(JsUndefined)
     }
 
     "return float conversion for big decimal" in {
-      JsBigDecimal(BigDecimal(6.0F)).toFloat should equal(6.0F)
+      JsBigDecimal.fromLiteral(BigDecimal(6.0F)).toFloat should equal(6.0F)
     }
 
     "return int conversion for float" in {
-      JsFloat(2.0F).toInt should equal(2)
+      JsFloat.fromLiteral(2.0F).toInt should equal(2)
     }
 
     "return long conversion for float" in {
-      JsFloat(2.0F).toLong should equal(2L)
+      JsFloat.fromLiteral(2.0F).toLong should equal(2L)
     }
 
     "return float conversion for float" in {
-      JsFloat(2.0F).toFloat should equal(2.0F)
+      JsFloat.fromLiteral(2.0F).toFloat should equal(2.0F)
     }
 
     "return double conversion for float" in {
-      JsFloat(2.0F).toDouble should equal(2.0D)
+      JsFloat.fromLiteral(2.0F).toDouble should equal(2.0D)
     }
 
     "return big decimal conversion for float" in {
-      JsFloat(2.0F).toBigDecimal should equal(BigDecimal(2.0F))
+      JsFloat.fromLiteral(2.0F).toBigDecimal should equal(BigDecimal(2.0F))
     }
 
     "return correct size for float" in {
-      JsFloat(2.0F).sizeHint should equal(3)
+      JsFloat.fromLiteral(2.0F).sizeHint should equal(3)
     }
 
     "be identified as number" in {
-      JsFloat(0F).isNumber should equal(true)
+      JsFloat.fromLiteral(0F).isNumber should equal(true)
     }
 
     "be identified as float" in {
-      JsFloat(0F).isFloat should equal(true)
+      JsFloat.fromLiteral(0F).isFloat should equal(true)
     }
   }
 
   "Json double" should {
     "stringify double correctly" in {
-      JsDouble(1.0D).toString should equal("1.0")
+      JsDouble.fromLiteral(1.0D).toString should equal("1.0")
     }
 
     "map json double correctly" in {
-      JsDouble(10D).map[Double](_ => JsNull) should equal(JsNull)
+      JsDouble.fromLiteral(10D).map[Double](_ => JsNull) should equal(JsNull)
       JsNull.map[Double](_ => JsNull) should equal(JsUndefined)
     }
 
     "return correct size for double" in {
-      JsDouble(2.0D).sizeHint should equal(3)
+      JsDouble.fromLiteral(2.0D).sizeHint should equal(3)
     }
 
     "return int conversion for double" in {
-      JsDouble(2.0D).toInt should equal(2)
+      JsDouble.fromLiteral(2.0D).toInt should equal(2)
     }
 
     "return long conversion for double" in {
-      JsDouble(2.0D).toLong should equal(2L)
+      JsDouble.fromLiteral(2.0D).toLong should equal(2L)
     }
 
     "return float conversion for double" in {
-      JsDouble(2.0D).toFloat should equal(2.0F)
+      JsDouble.fromLiteral(2.0D).toFloat should equal(2.0F)
     }
 
     "return double conversion for double" in {
-      JsDouble(2.0D).toDouble should equal(2.0D)
+      JsDouble.fromLiteral(2.0D).toDouble should equal(2.0D)
     }
 
     "return big decimal conversion for double" in {
-      JsDouble(2.0D).toBigDecimal should equal(BigDecimal(2.0D))
+      JsDouble.fromLiteral(2.0D).toBigDecimal should equal(BigDecimal(2.0D))
     }
 
     "be identified as number" in {
-      JsDouble(0D).isNumber should equal(true)
+      JsDouble.fromLiteral(0D).isNumber should equal(true)
     }
 
     "be identified as double" in {
-      JsDouble(0D).isDouble should equal(true)
+      JsDouble.fromLiteral(0D).isDouble should equal(true)
     }
   }
 
   "Json int" should {
     "stringify int correctly" in {
-      JsInt(0).toString should equal("0")
+      JsInt.fromLiteral(0).toString should equal("0")
     }
 
     "return correct size for int" in {
       // Positive cases
       var size = 1
       for (i <- 0 until String.valueOf(Int.MaxValue).length) {
-        JsInt(1 * IntMath.pow(10, i)).sizeHint should equal(size)
+        JsInt.fromLiteral(1 * IntMath.pow(10, i)).sizeHint should equal(size)
         size += 1
       }
 
       // Negative cases
       size = 2
       for (i <- 0 until String.valueOf(Int.MaxValue).length) {
-        JsInt(-1 * IntMath.pow(10, i)).sizeHint should equal(size)
+        JsInt.fromLiteral(-1 * IntMath.pow(10, i)).sizeHint should equal(size)
         size += 1
       }
     }
 
     "return int conversion for int" in {
-      JsInt(1).toInt should equal(1)
+      JsInt.fromLiteral(1).toInt should equal(1)
     }
 
     "return long conversion for int" in {
-      JsInt(1).toLong should equal(1L)
+      JsInt.fromLiteral(1).toLong should equal(1L)
     }
 
     "return float conversion for int" in {
-      JsInt(1).toFloat should equal(1.0F)
+      JsInt.fromLiteral(1).toFloat should equal(1.0F)
     }
 
     "return double conversion for int" in {
-      JsInt(1).toDouble should equal(1.0D)
+      JsInt.fromLiteral(1).toDouble should equal(1.0D)
     }
 
     "return big decimal conversion for int" in {
-      JsInt(1).toBigDecimal should equal(BigDecimal(1))
+      JsInt.fromLiteral(1).toBigDecimal should equal(BigDecimal(1))
     }
 
     "be identified as number" in {
-      JsInt(0).isNumber should equal(true)
+      JsInt.fromLiteral(0).isNumber should equal(true)
     }
 
     "be identified as int" in {
-      JsInt(0).isInt should equal(true)
+      JsInt.fromLiteral(0).isInt should equal(true)
     }
   }
 
@@ -612,90 +612,90 @@ class JsonSpec extends WordSpecLike with Matchers {
       // Positive cases
       var size = 1
       for (i <- 0 until String.valueOf(Long.MaxValue).length) {
-        JsLong(1 * LongMath.pow(10, i)).sizeHint should equal(size)
+        JsLong.fromLiteral(1 * LongMath.pow(10, i)).sizeHint should equal(size)
         size += 1
       }
 
       // Negative cases
       size = 2
       for (i <- 0 until String.valueOf(Long.MaxValue).length) {
-        JsLong(-1 * LongMath.pow(10, i)).sizeHint should equal(size)
+        JsLong.fromLiteral(-1 * LongMath.pow(10, i)).sizeHint should equal(size)
         size += 1
       }
     }
 
     "return int conversion for long" in {
-      JsLong(1L).toInt should equal(1)
+      JsLong.fromLiteral(1L).toInt should equal(1)
     }
 
     "return long conversion for long" in {
-      JsLong(1L).toLong should equal(1L)
+      JsLong.fromLiteral(1L).toLong should equal(1L)
     }
 
     "return float conversion for long" in {
-      JsLong(1L).toFloat should equal(1.0F)
+      JsLong.fromLiteral(1L).toFloat should equal(1.0F)
     }
 
     "return double conversion for long" in {
-      JsLong(1L).toDouble should equal(1.0D)
+      JsLong.fromLiteral(1L).toDouble should equal(1.0D)
     }
 
     "return big decimal conversion for long" in {
-      JsLong(1L).toBigDecimal should equal(BigDecimal(1))
+      JsLong.fromLiteral(1L).toBigDecimal should equal(BigDecimal(1))
     }
 
     "be identified as number" in {
-      JsLong(0).isNumber should equal(true)
+      JsLong.fromLiteral(0).isNumber should equal(true)
     }
 
     "be identified as long" in {
-      JsLong(0).isLong should equal(true)
+      JsLong.fromLiteral(0).isLong should equal(true)
     }
   }
 
   "Json big decimal" should {
     "return correct size for big decimal" in {
-      JsBigDecimal(BigDecimal("2e128")).sizeHint should equal(6)
+      JsBigDecimal.fromLiteral(BigDecimal("2e128")).sizeHint should equal(6)
     }
 
     "return int conversion for big decimal" in {
-      JsBigDecimal(BigDecimal(6)).toInt should equal(6)
+      JsBigDecimal.fromLiteral(BigDecimal(6)).toInt should equal(6)
     }
 
     "return long conversion for big decimal" in {
-      JsBigDecimal(BigDecimal(6L)).toLong should equal(6L)
+      JsBigDecimal.fromLiteral(BigDecimal(6L)).toLong should equal(6L)
     }
 
     "return double conversion for big decimal" in {
-      JsBigDecimal(BigDecimal(6.0D)).toDouble should equal(6.0D)
+      JsBigDecimal.fromLiteral(BigDecimal(6.0D)).toDouble should equal(6.0D)
     }
 
     "return big decimal conversion for big decimal" in {
-      JsBigDecimal(BigDecimal("2e128")).toBigDecimal should equal(BigDecimal("2e128"))
+      JsBigDecimal.fromLiteral(BigDecimal("2e128")).toBigDecimal should equal(BigDecimal("2e128"))
     }
 
     "be identified as big decimal" in {
-      JsBigDecimal(BigDecimal(0F)).isBigDecimal should equal(true)
+      JsBigDecimal.fromLiteral(BigDecimal(0F)).isBigDecimal should equal(true)
     }
   }
 
   "Json string" should {
     "return correct size for string" in {
-      JsString("test").sizeHint should equal(6) // "test"
+      JsString.fromLiteral("test").sizeHint should equal(6) // "test"
     }
 
     "be identified as string" in {
-      JsString("").isString should equal(true)
+      JsString.fromLiteral("").isString should equal(true)
     }
   }
 
   "Json bytes" should {
     "stringify bytestring correctly" in {
-      JsBytes(ByteString("test")).toString should equal("\"dGVzdA==\"")
+      JsBytes.fromLiteral(ByteString("test")).toString should equal("\"dGVzdA==\"")
     }
 
     "be identified as bytes" in {
-      JsBytes(ByteString.empty).isBytes should equal(true)
+      JsBytes.fromLiteral(ByteString.empty).isBytes should equal(true)
     }
   }
 
@@ -808,17 +808,17 @@ class JsonSpec extends WordSpecLike with Matchers {
     }
 
     "map json big decimal correctly" in {
-      JsBigDecimal(BigDecimal(10D)).map[BigDecimal](_ => JsNull) should equal(JsNull)
+      JsBigDecimal.fromLiteral(BigDecimal(10D)).map[BigDecimal](_ => JsNull) should equal(JsNull)
       JsNull.map[BigDecimal](_ => JsNull) should equal(JsUndefined)
     }
 
     "map json string correctly" in {
-      JsString("test").map[String](_ => JsNull) should equal(JsNull)
+      JsString.fromLiteral("test").map[String](_ => JsNull) should equal(JsNull)
       JsNull.map[String](_ => JsNull) should equal(JsUndefined)
     }
 
     "map json byte string correctly" in {
-      JsBytes(ByteString("test")).map[ByteString](_ => JsNull) should equal(JsNull)
+      JsBytes.fromLiteral(ByteString("test")).map[ByteString](_ => JsNull) should equal(JsNull)
       JsNull.map[ByteString](_ => JsNull) should equal(JsUndefined)
     }
 
@@ -848,37 +848,37 @@ class JsonSpec extends WordSpecLike with Matchers {
     }
 
     "flatMap json int correctly" in {
-      JsInt(10).flatMap[Int](_ => JsNull) should equal(JsNull)
+      JsInt.fromLiteral(10).flatMap[Int](_ => JsNull) should equal(JsNull)
       JsNull.flatMap[Int](_ => JsNull) should equal(JsUndefined)
     }
 
     "flatMap json long correctly" in {
-      JsLong(10L).flatMap[Long](_ => JsNull) should equal(JsNull)
+      JsLong.fromLiteral(10L).flatMap[Long](_ => JsNull) should equal(JsNull)
       JsNull.flatMap[Long](_ => JsNull) should equal(JsUndefined)
     }
 
     "flatMap json float correctly" in {
-      JsFloat(10F).flatMap[Float](_ => JsNull) should equal(JsNull)
+      JsFloat.fromLiteral(10F).flatMap[Float](_ => JsNull) should equal(JsNull)
       JsNull.flatMap[Float](_ => JsNull) should equal(JsUndefined)
     }
 
     "flatMap json double correctly" in {
-      JsDouble(10D).flatMap[Double](_ => JsNull) should equal(JsNull)
+      JsDouble.fromLiteral(10D).flatMap[Double](_ => JsNull) should equal(JsNull)
       JsNull.flatMap[Double](_ => JsNull) should equal(JsUndefined)
     }
 
     "flatMap json big decimal correctly" in {
-      JsBigDecimal(BigDecimal(10D)).flatMap[BigDecimal](_ => JsNull) should equal(JsNull)
+      JsBigDecimal.fromLiteral(BigDecimal(10D)).flatMap[BigDecimal](_ => JsNull) should equal(JsNull)
       JsNull.flatMap[BigDecimal](_ => JsNull) should equal(JsUndefined)
     }
 
     "flatMap json string correctly" in {
-      JsString("test").flatMap[String](_ => JsNull) should equal(JsNull)
+      JsString.fromLiteral("test").flatMap[String](_ => JsNull) should equal(JsNull)
       JsNull.flatMap[String](_ => JsNull) should equal(JsUndefined)
     }
 
     "flatMap json byte string correctly" in {
-      JsBytes(ByteString("test")).flatMap[ByteString](_ => JsNull) should equal(JsNull)
+      JsBytes.fromLiteral(ByteString("test")).flatMap[ByteString](_ => JsNull) should equal(JsNull)
       JsNull.flatMap[ByteString](_ => JsNull) should equal(JsUndefined)
     }
 
@@ -888,7 +888,7 @@ class JsonSpec extends WordSpecLike with Matchers {
 
     "get json correctly" in {
       val input = Json.parseStringUnsafe("1330950829160")
-      input.get[Json] should equal(JsLong(1330950829160L))
+      input.get[Json] should equal(JsLong.fromLiteral(1330950829160L))
     }
 
     "get json array correctly" in {
@@ -900,7 +900,7 @@ class JsonSpec extends WordSpecLike with Matchers {
     }
 
     "get json number correctly" in {
-      JsInt(10).get[JsNumber] should equal(JsInt(10))
+      JsInt.fromLiteral(10).get[JsNumber] should equal(JsInt.fromLiteral(10))
     }
 
     "get boolean correctly" in {
@@ -909,31 +909,31 @@ class JsonSpec extends WordSpecLike with Matchers {
     }
 
     "get int correctly" in {
-      JsInt(10).get[Int] should equal(10)
+      JsInt.fromLiteral(10).get[Int] should equal(10)
     }
 
     "get long correctly" in {
-      JsLong(10L).get[Long] should equal(10)
+      JsLong.fromLiteral(10L).get[Long] should equal(10)
     }
 
     "get float correctly" in {
-      JsFloat(10F).get[Float] should equal(10F)
+      JsFloat.fromLiteral(10F).get[Float] should equal(10F)
     }
 
     "get double correctly" in {
-      JsDouble(10D).get[Double] should equal(10D)
+      JsDouble.fromLiteral(10D).get[Double] should equal(10D)
     }
 
     "get big decimal correctly" in {
-      JsBigDecimal(BigDecimal(10D)).get[BigDecimal] should equal(BigDecimal(10D))
+      JsBigDecimal.fromLiteral(BigDecimal(10D)).get[BigDecimal] should equal(BigDecimal(10D))
     }
 
     "get string correctly" in {
-      JsString("test").get[String] should equal("test")
+      JsString.fromLiteral("test").get[String] should equal("test")
     }
 
     "get byte string correctly" in {
-      JsBytes(ByteString("test")).get[ByteString] should equal(ByteString("test"))
+      JsBytes.fromLiteral(ByteString("test")).get[ByteString] should equal(ByteString("test"))
     }
 
     "get json undefined correctly" in {
@@ -943,7 +943,7 @@ class JsonSpec extends WordSpecLike with Matchers {
     }
 
     "getOrElse json correctly" in {
-      JsLong(1330950829160L).getOrElse[Json](JsNull) should equal(JsLong(1330950829160L))
+      JsLong.fromLiteral(1330950829160L).getOrElse[Json](JsNull) should equal(JsLong.fromLiteral(1330950829160L))
       JsUndefined.getOrElse[Json](JsNull) should equal(JsNull)
     }
 
@@ -958,8 +958,8 @@ class JsonSpec extends WordSpecLike with Matchers {
     }
 
     "getOrElse json number correctly" in {
-      JsInt(10).getOrElse[JsNumber](JsInt(0)) should equal(JsInt(10))
-      JsNull.getOrElse[JsNumber](JsInt(0)) should equal(JsInt(0))
+      JsInt.fromLiteral(10).getOrElse[JsNumber](JsInt.fromLiteral(0)) should equal(JsInt.fromLiteral(10))
+      JsNull.getOrElse[JsNumber](JsInt.fromLiteral(0)) should equal(JsInt.fromLiteral(0))
     }
 
     "getOrElse boolean correctly" in {
@@ -969,37 +969,37 @@ class JsonSpec extends WordSpecLike with Matchers {
     }
 
     "getOrElse int correctly" in {
-      JsInt(10).getOrElse[Int](0) should equal(10)
+      JsInt.fromLiteral(10).getOrElse[Int](0) should equal(10)
       JsNull.getOrElse[Int](0) should equal(0)
     }
 
     "getOrElse long correctly" in {
-      JsLong(10L).getOrElse[Long](0) should equal(10)
+      JsLong.fromLiteral(10L).getOrElse[Long](0) should equal(10)
       JsNull.getOrElse[Long](0) should equal(0)
     }
 
     "getOrElse float correctly" in {
-      JsFloat(10F).getOrElse[Float](0F) should equal(10F)
+      JsFloat.fromLiteral(10F).getOrElse[Float](0F) should equal(10F)
       JsNull.getOrElse[Float](0F) should equal(0F)
     }
 
     "getOrElse double correctly" in {
-      JsDouble(10D).getOrElse[Double](0D) should equal(10D)
+      JsDouble.fromLiteral(10D).getOrElse[Double](0D) should equal(10D)
       JsNull.getOrElse[Double](0D) should equal(0D)
     }
 
     "getOrElse big decimal correctly" in {
-      JsBigDecimal(BigDecimal(10D)).getOrElse[BigDecimal](BigDecimal(0)) should equal(BigDecimal(10D))
+      JsBigDecimal.fromLiteral(BigDecimal(10D)).getOrElse[BigDecimal](BigDecimal(0)) should equal(BigDecimal(10D))
       JsNull.getOrElse[BigDecimal](0) should equal(BigDecimal(0))
     }
 
     "getOrElse string correctly" in {
-      JsString("test").getOrElse[String]("") should equal("test")
+      JsString.fromLiteral("test").getOrElse[String]("") should equal("test")
       JsNull.getOrElse[String]("") should equal("")
     }
 
     "getOrElse byte string correctly" in {
-      JsBytes(ByteString("test")).getOrElse[ByteString](ByteString.empty) should equal(ByteString("test"))
+      JsBytes.fromLiteral(ByteString("test")).getOrElse[ByteString](ByteString.empty) should equal(ByteString("test"))
       JsNull.getOrElse[ByteString](ByteString.empty) should equal(ByteString.empty)
     }
 
@@ -1024,31 +1024,31 @@ class JsonSpec extends WordSpecLike with Matchers {
     }
 
     "process if exists json int correctly" in {
-      JsInt(10).ifExists[Int](_ => JsNull)
+      JsInt.fromLiteral(10).ifExists[Int](_ => JsNull)
     }
 
     "process if exists json long correctly" in {
-      JsLong(10L).ifExists[Long](_ => JsNull)
+      JsLong.fromLiteral(10L).ifExists[Long](_ => JsNull)
     }
 
     "process if exists json float correctly" in {
-      JsFloat(10F).ifExists[Float](_ => JsNull)
+      JsFloat.fromLiteral(10F).ifExists[Float](_ => JsNull)
     }
 
     "process if exists json double correctly" in {
-      JsDouble(10D).ifExists[Double](_ => JsNull)
+      JsDouble.fromLiteral(10D).ifExists[Double](_ => JsNull)
     }
 
     "process if exists json big decimal correctly" in {
-      JsBigDecimal(BigDecimal(10D)).ifExists[BigDecimal](_ => JsNull)
+      JsBigDecimal.fromLiteral(BigDecimal(10D)).ifExists[BigDecimal](_ => JsNull)
     }
 
     "process if exists json string correctly" in {
-      JsString("test").ifExists[String](_ => JsNull)
+      JsString.fromLiteral("test").ifExists[String](_ => JsNull)
     }
 
     "process if exists json byte string correctly" in {
-      JsBytes(ByteString("test")).ifExists[ByteString](_ => JsNull)
+      JsBytes.fromLiteral(ByteString("test")).ifExists[ByteString](_ => JsNull)
     }
 
     "process if exists json undefined correctly" in {
@@ -1062,47 +1062,47 @@ class JsonSpec extends WordSpecLike with Matchers {
 
     "parse long integers correctly" in {
       val input = Json.parseStringUnsafe("1330950829160")
-      input should equal(JsLong(1330950829160L))
+      input should equal(JsLong.fromLiteral(1330950829160L))
     }
 
     "parse short integers correctly" in {
       val input = Json.parseStringUnsafe("1234")
-      input should equal(JsInt(1234))
+      input should equal(JsInt.fromLiteral(1234))
     }
 
     "parse byte integers correctly" in {
       val input = Json.parseStringUnsafe("123")
-      input should equal(JsInt(123))
+      input should equal(JsInt.fromLiteral(123))
     }
 
     "parse big decimal correctly" in {
       val input = Json.parseStringUnsafe("12345678901234567890.42")
-      input should equal(JsBigDecimal(BigDecimal("12345678901234567890.42")))
+      input should equal(JsBigDecimal.fromLiteral(BigDecimal("12345678901234567890.42")))
     }
 
     "parse big decimal with large exponents in scientific notation correctly" in {
       val input = Json.parseStringUnsafe("1.2e1000")
-      input should equal(JsBigDecimal(BigDecimal("1.2e1000")))
+      input should equal(JsBigDecimal.fromLiteral(BigDecimal("1.2e1000")))
     }
 
     "parse big decimal with large negative exponents in scientific notation correctly" in {
       val input = Json.parseStringUnsafe("6.75e-1000")
-      input should equal(JsBigDecimal(BigDecimal("6.75e-1000")))
+      input should equal(JsBigDecimal.fromLiteral(BigDecimal("6.75e-1000")))
     }
 
     "parse big decimal with small exponents in scientific notation correctly" in {
       val input = Json.parseStringUnsafe("1.234e3")
-      input should equal(JsBigDecimal(BigDecimal("1.234e3")))
+      input should equal(JsBigDecimal.fromLiteral(BigDecimal("1.234e3")))
     }
 
     "parse big decimal with small negative exponents in scientific notation correctly" in {
       val input = Json.parseStringUnsafe("1.234e-3")
-      input should equal(JsBigDecimal(BigDecimal("1.234e-3")))
+      input should equal(JsBigDecimal.fromLiteral(BigDecimal("1.234e-3")))
     }
 
     "parse big decimal with integer base correctly" in {
       val input = Json.parseStringUnsafe("2e128")
-      input should equal(JsBigDecimal(BigDecimal("2e128")))
+      input should equal(JsBigDecimal.fromLiteral(BigDecimal("2e128")))
     }
 
     "parse list correctly" in {

--- a/core/src/test/scala/io/techcode/streamy/util/json/JsonSpec.scala
+++ b/core/src/test/scala/io/techcode/streamy/util/json/JsonSpec.scala
@@ -510,6 +510,18 @@ class JsonSpec extends WordSpecLike with Matchers {
       JsFloat.fromStringUnsafe("2.0").sizeHint should equal(3)
     }
 
+    "support pattern matching" in {
+      JsFloat.fromLiteral(2.0F) match {
+        case x: JsFloat => x.value should equal(2.0F)
+      }
+      JsFloat.fromByteStringUnsafe(ByteString("2.0")) match {
+        case x: JsFloat => x.value should equal(2.0F)
+      }
+      JsFloat.fromStringUnsafe("2.0") match {
+        case x: JsFloat => x.value should equal(2.0F)
+      }
+    }
+
     "be identified as number" in {
       JsFloat.fromLiteral(0F).isNumber should equal(true)
       JsFloat.fromByteStringUnsafe(ByteString("0")).isNumber should equal(true)
@@ -569,6 +581,18 @@ class JsonSpec extends WordSpecLike with Matchers {
       JsDouble.fromLiteral(2.0D).toBigDecimal should equal(BigDecimal(2.0D))
       JsDouble.fromByteStringUnsafe(ByteString("2.0")).toBigDecimal should equal(BigDecimal(2.0D))
       JsDouble.fromStringUnsafe("2.0").toBigDecimal should equal(BigDecimal(2.0D))
+    }
+
+    "support pattern matching" in {
+      JsDouble.fromLiteral(2.0D) match {
+        case x: JsDouble => x.value should equal(2.0D)
+      }
+      JsDouble.fromByteStringUnsafe(ByteString("2.0")) match {
+        case x: JsDouble => x.value should equal(2.0D)
+      }
+      JsDouble.fromStringUnsafe("2.0") match {
+        case x: JsDouble => x.value should equal(2.0F)
+      }
     }
 
     "be identified as number" in {
@@ -637,6 +661,18 @@ class JsonSpec extends WordSpecLike with Matchers {
       JsInt.fromStringUnsafe("1").toBigDecimal should equal(BigDecimal(1))
     }
 
+    "support pattern matching" in {
+      JsInt.fromLiteral(1) match {
+        case x: JsInt => x.value should equal(1)
+      }
+      JsInt.fromByteStringUnsafe(ByteString("1")) match {
+        case x: JsInt => x.value should equal(1)
+      }
+      JsInt.fromStringUnsafe("1") match {
+        case x: JsInt => x.value should equal(1)
+      }
+    }
+
     "be identified as number" in {
       JsInt.fromLiteral(0).isNumber should equal(true)
       JsInt.fromByteStringUnsafe(ByteString("0")).isNumber should equal(true)
@@ -703,6 +739,18 @@ class JsonSpec extends WordSpecLike with Matchers {
       JsLong.fromStringUnsafe("1").toBigDecimal should equal(BigDecimal(1))
     }
 
+    "support pattern matching" in {
+      JsLong.fromLiteral(1L) match {
+        case x: JsLong => x.value should equal(1L)
+      }
+      JsLong.fromByteStringUnsafe(ByteString("1")) match {
+        case x: JsLong => x.value should equal(1L)
+      }
+      JsLong.fromStringUnsafe("1") match {
+        case x: JsLong => x.value should equal(1L)
+      }
+    }
+
     "be identified as number" in {
       JsLong.fromLiteral(0).isNumber should equal(true)
       JsLong.fromByteStringUnsafe(ByteString("0")).isNumber should equal(true)
@@ -747,6 +795,18 @@ class JsonSpec extends WordSpecLike with Matchers {
       JsBigDecimal.fromStringUnsafe("2e128").toBigDecimal should equal(BigDecimal("2e128"))
     }
 
+    "support pattern matching" in {
+      JsBigDecimal.fromLiteral(BigDecimal("2e128")) match {
+        case x: JsBigDecimal => x.value should equal(BigDecimal("2e128"))
+      }
+      JsBigDecimal.fromByteStringUnsafe(ByteString("2e128")) match {
+        case x: JsBigDecimal => x.value should equal(BigDecimal("2e128"))
+      }
+      JsBigDecimal.fromStringUnsafe("2e128") match {
+        case x: JsBigDecimal => x.value should equal(BigDecimal("2e128"))
+      }
+    }
+
     "be identified as big decimal" in {
       JsBigDecimal.fromLiteral(BigDecimal(0F)).isBigDecimal should equal(true)
       JsBigDecimal.fromByteStringUnsafe(ByteString("0")).isBigDecimal should equal(true)
@@ -760,6 +820,15 @@ class JsonSpec extends WordSpecLike with Matchers {
       JsString.fromByteStringUnsafe(ByteString("test")).sizeHint should equal(6) // "test"
     }
 
+    "support pattern matching" in {
+      JsString.fromLiteral("test") match {
+        case x: JsString => x.value should equal("test")
+      }
+      JsString.fromByteStringUnsafe(ByteString("test")) match {
+        case x: JsString => x.value should equal("test")
+      }
+    }
+
     "be identified as string" in {
       JsString.fromLiteral("").isString should equal(true)
       JsString.fromByteStringUnsafe(ByteString("")).isString should equal(true)
@@ -770,6 +839,15 @@ class JsonSpec extends WordSpecLike with Matchers {
     "stringify bytestring correctly" in {
       JsBytes.fromLiteral(ByteString("test")).toString should equal("\"dGVzdA==\"")
       JsBytes.fromStringUnsafe("test").toString should equal("\"dGVzdA==\"")
+    }
+
+    "support pattern matching" in {
+      JsBytes.fromLiteral(ByteString("test")) match {
+        case x: JsBytes => x.value should equal(ByteString("test"))
+      }
+      JsBytes.fromStringUnsafe("test") match {
+        case x: JsBytes => x.value should equal(ByteString("test"))
+      }
     }
 
     "be identified as bytes" in {

--- a/core/src/test/scala/io/techcode/streamy/util/json/JsonSpec.scala
+++ b/core/src/test/scala/io/techcode/streamy/util/json/JsonSpec.scala
@@ -464,6 +464,7 @@ class JsonSpec extends WordSpecLike with Matchers {
 
   "Json float" should {
     "stringify float correctly" in {
+      JsFloat(1.0F).toString should equal("1.0")
       JsFloat.fromLiteral(1.0F).toString should equal("1.0")
       JsFloat.fromByteStringUnsafe(ByteString("1.0")).toString should equal("1.0")
       JsFloat.fromStringUnsafe("1.0").toString should equal("1.0")
@@ -554,6 +555,7 @@ class JsonSpec extends WordSpecLike with Matchers {
 
   "Json double" should {
     "stringify double correctly" in {
+      JsDouble(1.0D).toString should equal("1.0")
       JsDouble.fromLiteral(1.0D).toString should equal("1.0")
       JsDouble.fromByteStringUnsafe(ByteString("1.0")).toString should equal("1.0")
       JsDouble.fromStringUnsafe("1.0").toString should equal("1.0")
@@ -644,6 +646,7 @@ class JsonSpec extends WordSpecLike with Matchers {
 
   "Json int" should {
     "stringify int correctly" in {
+      JsInt(0).toString should equal("0")
       JsInt.fromLiteral(0).toString should equal("0")
       JsInt.fromByteStringUnsafe(ByteString("0")).toString should equal("0")
       JsInt.fromStringUnsafe("0").toString should equal("0")
@@ -739,6 +742,7 @@ class JsonSpec extends WordSpecLike with Matchers {
 
   "Json long" should {
     "stringify long integers correctly" in {
+      JsLong(1330950829160L).toString should equal("1330950829160")
       JsLong.fromLiteral(1330950829160L).toString should equal("1330950829160")
       JsLong.fromByteStringUnsafe(ByteString("1330950829160")).toString should equal("1330950829160")
       JsLong.fromStringUnsafe("1330950829160").toString should equal("1330950829160")
@@ -834,6 +838,7 @@ class JsonSpec extends WordSpecLike with Matchers {
 
   "Json big decimal" should {
     "return correct size for big decimal" in {
+      JsBigDecimal(BigDecimal("2e128")).sizeHint should equal(6)
       JsBigDecimal.fromLiteral(BigDecimal("2e128")).sizeHint should equal(6)
       JsBigDecimal.fromByteStringUnsafe(ByteString("2e128")).sizeHint should equal(5)
       JsBigDecimal.fromStringUnsafe("2e128").sizeHint should equal(5)
@@ -849,6 +854,12 @@ class JsonSpec extends WordSpecLike with Matchers {
       JsBigDecimal.fromLiteral(BigDecimal(6.0D)).toLong should equal(6L)
       JsBigDecimal.fromByteStringUnsafe(ByteString("6.0")).toLong should equal(6L)
       JsBigDecimal.fromStringUnsafe("6.0").toLong should equal(6L)
+    }
+
+    "return float conversion for big decimal" in {
+      JsBigDecimal.fromLiteral(BigDecimal(6.0D)).toFloat should equal(6.0D)
+      JsBigDecimal.fromByteStringUnsafe(ByteString("6.0")).toFloat should equal(6.0D)
+      JsBigDecimal.fromStringUnsafe("6.0").toFloat should equal(6.0D)
     }
 
     "return double conversion for big decimal" in {
@@ -901,6 +912,7 @@ class JsonSpec extends WordSpecLike with Matchers {
 
   "Json string" should {
     "return correct size for string" in {
+      JsString("test").sizeHint should equal(6) // "test"
       JsString.fromLiteral("test").sizeHint should equal(6) // "test"
       JsString.fromByteStringUnsafe(ByteString("test")).sizeHint should equal(6) // "test"
     }
@@ -936,6 +948,7 @@ class JsonSpec extends WordSpecLike with Matchers {
 
   "Json bytes" should {
     "stringify bytestring correctly" in {
+      JsBytes(ByteString("test")).toString should equal("\"dGVzdA==\"")
       JsBytes.fromLiteral(ByteString("test")).toString should equal("\"dGVzdA==\"")
       JsBytes.fromStringUnsafe("test").toString should equal("\"dGVzdA==\"")
     }
@@ -1439,6 +1452,12 @@ class JsonSpec extends WordSpecLike with Matchers {
     }
 
     "provide a way to build json object" in {
+      assertThrows[NotImplementedError] {
+        Json.obj().addOne("foobar" -> 1)
+      }
+      assertThrows[NotImplementedError] {
+        Json.obj().clear()
+      }
       val builder = Json.objectBuilder()
       builder += "foobar" -> 1
       builder ++= Seq(
@@ -1451,6 +1470,12 @@ class JsonSpec extends WordSpecLike with Matchers {
     }
 
     "provide a way to build json array" in {
+      assertThrows[NotImplementedError] {
+        Json.arr().addOne("foobar")
+      }
+      assertThrows[NotImplementedError] {
+        Json.arr().clear()
+      }
       val builder = Json.arrayBuilder()
       builder += "foobar"
       builder ++= Seq(1, 2)

--- a/core/src/test/scala/io/techcode/streamy/util/json/JsonSpec.scala
+++ b/core/src/test/scala/io/techcode/streamy/util/json/JsonSpec.scala
@@ -512,14 +512,31 @@ class JsonSpec extends WordSpecLike with Matchers {
 
     "support pattern matching" in {
       JsFloat.fromLiteral(2.0F) match {
+        case JsFloat(x) => x should equal(2.0F)
         case x: JsFloat => x.value should equal(2.0F)
       }
       JsFloat.fromByteStringUnsafe(ByteString("2.0")) match {
+        case JsFloat(x) => x should equal(2.0F)
         case x: JsFloat => x.value should equal(2.0F)
       }
       JsFloat.fromStringUnsafe("2.0") match {
+        case JsFloat(x) => x should equal(2.0F)
         case x: JsFloat => x.value should equal(2.0F)
       }
+    }
+
+    "be equal to float" in {
+      JsFloat.fromLiteral(2.0F) should equal(JsFloat.fromLiteral(2.0F))
+      JsFloat.fromLiteral(2.0F) should equal(JsFloat.fromByteStringUnsafe(ByteString("2.0")))
+      JsFloat.fromLiteral(2.0F) should equal(JsFloat.fromStringUnsafe("2.0"))
+      JsFloat.fromLiteral(0.0F) should not equal(JsFloat.fromLiteral(2.0F))
+      JsFloat.fromLiteral(0.0F) should not equal(JsInt.fromLiteral(2))
+    }
+
+    "be equal to hashCode float" in {
+      JsFloat.fromLiteral(2.0F).hashCode() should equal(JsFloat.fromLiteral(2.0F).hashCode())
+      JsFloat.fromLiteral(2.0F).hashCode() should equal(JsFloat.fromByteStringUnsafe(ByteString("2.0")).hashCode())
+      JsFloat.fromLiteral(2.0F).hashCode() should equal(JsFloat.fromStringUnsafe("2.0").hashCode())
     }
 
     "be identified as number" in {
@@ -585,14 +602,31 @@ class JsonSpec extends WordSpecLike with Matchers {
 
     "support pattern matching" in {
       JsDouble.fromLiteral(2.0D) match {
+        case JsDouble(x) => x should equal(2.0D)
         case x: JsDouble => x.value should equal(2.0D)
       }
       JsDouble.fromByteStringUnsafe(ByteString("2.0")) match {
+        case JsDouble(x) => x should equal(2.0D)
         case x: JsDouble => x.value should equal(2.0D)
       }
       JsDouble.fromStringUnsafe("2.0") match {
-        case x: JsDouble => x.value should equal(2.0F)
+        case JsDouble(x) => x should equal(2.0D)
+        case x: JsDouble => x.value should equal(2.0D)
       }
+    }
+
+    "be equal to double" in {
+      JsDouble.fromLiteral(0.0D) should equal(JsDouble.fromLiteral(0.0F))
+      JsDouble.fromLiteral(0.0D) should equal(JsDouble.fromByteStringUnsafe(ByteString("0.0")))
+      JsDouble.fromLiteral(0.0D) should equal(JsDouble.fromStringUnsafe("0.0"))
+      JsDouble.fromLiteral(0.0D) should not equal(JsDouble.fromLiteral(2.0D))
+      JsDouble.fromLiteral(0.0D) should not equal(JsInt.fromLiteral(0))
+    }
+
+    "be equal to hashCode double" in {
+      JsDouble.fromLiteral(0.0D).hashCode() should equal(JsDouble.fromLiteral(0.0F).hashCode())
+      JsDouble.fromLiteral(0.0D).hashCode() should equal(JsDouble.fromByteStringUnsafe(ByteString("0.0")).hashCode())
+      JsDouble.fromLiteral(0.0D).hashCode() should equal(JsDouble.fromStringUnsafe("0.0").hashCode())
     }
 
     "be identified as number" in {
@@ -663,14 +697,31 @@ class JsonSpec extends WordSpecLike with Matchers {
 
     "support pattern matching" in {
       JsInt.fromLiteral(1) match {
+        case JsInt(x) => x should equal(1)
         case x: JsInt => x.value should equal(1)
       }
       JsInt.fromByteStringUnsafe(ByteString("1")) match {
+        case JsInt(x) => x should equal(1)
         case x: JsInt => x.value should equal(1)
       }
       JsInt.fromStringUnsafe("1") match {
+        case JsInt(x) => x should equal(1)
         case x: JsInt => x.value should equal(1)
       }
+    }
+
+    "be equal to int" in {
+      JsInt.fromLiteral(0) should equal(JsInt.fromLiteral(0))
+      JsInt.fromLiteral(0) should equal(JsInt.fromByteStringUnsafe(ByteString("0")))
+      JsInt.fromLiteral(0) should equal(JsInt.fromStringUnsafe("0"))
+      JsInt.fromLiteral(0) should not equal(JsInt.fromLiteral(2))
+      JsInt.fromLiteral(0) should not equal(JsDouble.fromLiteral(0.0D))
+    }
+
+    "be equal to hashCode int" in {
+      JsInt.fromLiteral(0).hashCode() should equal(JsInt.fromLiteral(0).hashCode())
+      JsInt.fromLiteral(0).hashCode() should equal(JsInt.fromByteStringUnsafe(ByteString("0")).hashCode())
+      JsInt.fromLiteral(0).hashCode() should equal(JsInt.fromStringUnsafe("0").hashCode())
     }
 
     "be identified as number" in {
@@ -741,14 +792,31 @@ class JsonSpec extends WordSpecLike with Matchers {
 
     "support pattern matching" in {
       JsLong.fromLiteral(1L) match {
+        case JsLong(x) => x should equal(1L)
         case x: JsLong => x.value should equal(1L)
       }
       JsLong.fromByteStringUnsafe(ByteString("1")) match {
+        case JsLong(x) => x should equal(1L)
         case x: JsLong => x.value should equal(1L)
       }
       JsLong.fromStringUnsafe("1") match {
+        case JsLong(x) => x should equal(1L)
         case x: JsLong => x.value should equal(1L)
       }
+    }
+
+    "be equal to long" in {
+      JsLong.fromLiteral(0L) should equal(JsLong.fromLiteral(0L))
+      JsLong.fromLiteral(0L) should equal(JsLong.fromByteStringUnsafe(ByteString("0")))
+      JsLong.fromLiteral(0L) should equal(JsLong.fromStringUnsafe("0"))
+      JsLong.fromLiteral(0L) should not equal(JsLong.fromLiteral(2))
+      JsLong.fromLiteral(0) should not equal(JsDouble.fromLiteral(0.0D))
+    }
+
+    "be equal to hashCode long" in {
+      JsLong.fromLiteral(0).hashCode() should equal(JsLong.fromLiteral(0).hashCode())
+      JsLong.fromLiteral(0).hashCode() should equal(JsLong.fromByteStringUnsafe(ByteString("0")).hashCode())
+      JsLong.fromLiteral(0).hashCode() should equal(JsLong.fromStringUnsafe("0").hashCode())
     }
 
     "be identified as number" in {
@@ -797,14 +865,31 @@ class JsonSpec extends WordSpecLike with Matchers {
 
     "support pattern matching" in {
       JsBigDecimal.fromLiteral(BigDecimal("2e128")) match {
+        case JsBigDecimal(x) => x should equal(BigDecimal("2e128"))
         case x: JsBigDecimal => x.value should equal(BigDecimal("2e128"))
       }
       JsBigDecimal.fromByteStringUnsafe(ByteString("2e128")) match {
+        case JsBigDecimal(x) => x should equal(BigDecimal("2e128"))
         case x: JsBigDecimal => x.value should equal(BigDecimal("2e128"))
       }
       JsBigDecimal.fromStringUnsafe("2e128") match {
+        case JsBigDecimal(x) => x should equal(BigDecimal("2e128"))
         case x: JsBigDecimal => x.value should equal(BigDecimal("2e128"))
       }
+    }
+
+    "be equal to big decimal" in {
+      JsBigDecimal.fromLiteral(BigDecimal(0)) should equal(JsBigDecimal.fromLiteral(BigDecimal(0)))
+      JsBigDecimal.fromLiteral(BigDecimal(0)) should equal(JsBigDecimal.fromByteStringUnsafe(ByteString("0")))
+      JsBigDecimal.fromLiteral(BigDecimal(0)) should equal(JsBigDecimal.fromStringUnsafe("0"))
+      JsBigDecimal.fromLiteral(BigDecimal(0)) should not equal(JsBigDecimal.fromLiteral(BigDecimal(2)))
+      JsBigDecimal.fromLiteral(BigDecimal(0)) should not equal(JsInt.fromLiteral(0))
+    }
+
+    "be equal to hashCode big decimal" in {
+      JsBigDecimal.fromLiteral(0).hashCode() should equal(JsBigDecimal.fromLiteral(0).hashCode())
+      JsBigDecimal.fromLiteral(0).hashCode() should equal(JsBigDecimal.fromByteStringUnsafe(ByteString("0")).hashCode())
+      JsBigDecimal.fromLiteral(0).hashCode() should equal(JsBigDecimal.fromStringUnsafe("0").hashCode())
     }
 
     "be identified as big decimal" in {
@@ -822,11 +907,25 @@ class JsonSpec extends WordSpecLike with Matchers {
 
     "support pattern matching" in {
       JsString.fromLiteral("test") match {
+        case JsString(x) => x should equal("test")
         case x: JsString => x.value should equal("test")
       }
       JsString.fromByteStringUnsafe(ByteString("test")) match {
+        case JsString(x) => x should equal("test")
         case x: JsString => x.value should equal("test")
       }
+    }
+
+    "be equal to string" in {
+      JsString.fromLiteral("foobar") should equal(JsString.fromLiteral("foobar"))
+      JsString.fromLiteral("foobar") should equal(JsString.fromByteStringUnsafe(ByteString("foobar")))
+      JsString.fromLiteral("foobar") should not equal(JsString.fromLiteral("foo"))
+      JsString.fromLiteral("foobar") should not equal(JsInt.fromLiteral(0))
+    }
+
+    "be equal to hashCode string" in {
+      JsString.fromLiteral("foobar").hashCode() should equal(JsString.fromLiteral("foobar").hashCode())
+      JsString.fromLiteral("foobar").hashCode() should equal(JsString.fromByteStringUnsafe(ByteString("foobar")).hashCode())
     }
 
     "be identified as string" in {
@@ -843,11 +942,25 @@ class JsonSpec extends WordSpecLike with Matchers {
 
     "support pattern matching" in {
       JsBytes.fromLiteral(ByteString("test")) match {
+        case JsBytes(x) => x should equal(ByteString("test"))
         case x: JsBytes => x.value should equal(ByteString("test"))
       }
       JsBytes.fromStringUnsafe("test") match {
+        case JsBytes(x) => x should equal(ByteString("test"))
         case x: JsBytes => x.value should equal(ByteString("test"))
       }
+    }
+
+    "be equal to bytes" in {
+      JsBytes.fromLiteral(ByteString("foobar")) should equal(JsBytes.fromLiteral(ByteString("foobar")))
+      JsBytes.fromLiteral(ByteString("foobar")) should equal(JsBytes.fromStringUnsafe("foobar"))
+      JsBytes.fromLiteral(ByteString("foobar")) should not equal(JsBytes.fromLiteral(ByteString("foo")))
+      JsBytes.fromLiteral(ByteString("foobar")) should not equal(JsInt.fromLiteral(0))
+    }
+
+    "be equal to hashCode bytes" in {
+      JsBytes.fromLiteral(ByteString("foobar")).hashCode() should equal(JsBytes.fromLiteral(ByteString("foobar")).hashCode())
+      JsBytes.fromLiteral(ByteString("foobar")).hashCode() should equal(JsBytes.fromStringUnsafe("foobar").hashCode())
     }
 
     "be identified as bytes" in {
@@ -1323,6 +1436,27 @@ class JsonSpec extends WordSpecLike with Matchers {
       result should equal(Json.obj(
         "foobar" -> "test"
       ))
+    }
+
+    "provide a way to build json object" in {
+      val builder = Json.objectBuilder()
+      builder += "foobar" -> 1
+      builder ++= Seq(
+        "foobar" -> 1,
+        "foobar2" -> 2
+      )
+      if (builder.knownSize >= 0) {
+        builder.clear()
+      }
+    }
+
+    "provide a way to build json array" in {
+      val builder = Json.arrayBuilder()
+      builder += "foobar"
+      builder ++= Seq(1, 2)
+      if (builder.knownSize >= 0) {
+        builder.clear()
+      }
     }
   }
 

--- a/core/src/test/scala/io/techcode/streamy/util/json/JsonSpec.scala
+++ b/core/src/test/scala/io/techcode/streamy/util/json/JsonSpec.scala
@@ -465,6 +465,8 @@ class JsonSpec extends WordSpecLike with Matchers {
   "Json float" should {
     "stringify float correctly" in {
       JsFloat.fromLiteral(1.0F).toString should equal("1.0")
+      JsFloat.fromByteStringUnsafe(ByteString("1.0")).toString should equal("1.0")
+      JsFloat.fromStringUnsafe("1.0").toString should equal("1.0")
     }
 
     "map json float correctly" in {
@@ -472,46 +474,60 @@ class JsonSpec extends WordSpecLike with Matchers {
       JsNull.map[Float](_ => JsNull) should equal(JsUndefined)
     }
 
-    "return float conversion for big decimal" in {
-      JsBigDecimal.fromLiteral(BigDecimal(6.0F)).toFloat should equal(6.0F)
-    }
-
     "return int conversion for float" in {
       JsFloat.fromLiteral(2.0F).toInt should equal(2)
+      JsFloat.fromByteStringUnsafe(ByteString("2.0")).toInt should equal(2)
+      JsFloat.fromStringUnsafe("2.0").toInt should equal(2)
     }
 
     "return long conversion for float" in {
       JsFloat.fromLiteral(2.0F).toLong should equal(2L)
+      JsFloat.fromByteStringUnsafe(ByteString("2.0")).toLong should equal(2L)
+      JsFloat.fromStringUnsafe("2.0").toLong should equal(2L)
     }
 
     "return float conversion for float" in {
-      JsFloat.fromLiteral(2.0F).toFloat should equal(2.0F)
+      JsFloat.fromLiteral(6.0F).toFloat should equal(6.0F)
+      JsFloat.fromByteStringUnsafe(ByteString("6.0")).toFloat should equal(6.0F)
+      JsFloat.fromStringUnsafe("6.0").toFloat should equal(6.0F)
     }
 
     "return double conversion for float" in {
       JsFloat.fromLiteral(2.0F).toDouble should equal(2.0D)
+      JsFloat.fromByteStringUnsafe(ByteString("2.0")).toDouble should equal(2.0D)
+      JsFloat.fromStringUnsafe("2.0").toDouble should equal(2.0D)
     }
 
     "return big decimal conversion for float" in {
       JsFloat.fromLiteral(2.0F).toBigDecimal should equal(BigDecimal(2.0F))
+      JsFloat.fromByteStringUnsafe(ByteString("2.0")).toBigDecimal should equal(BigDecimal(2.0F))
+      JsFloat.fromStringUnsafe("2.0").toBigDecimal should equal(BigDecimal(2.0F))
     }
 
     "return correct size for float" in {
       JsFloat.fromLiteral(2.0F).sizeHint should equal(3)
+      JsFloat.fromByteStringUnsafe(ByteString("2.0")).sizeHint should equal(3)
+      JsFloat.fromStringUnsafe("2.0").sizeHint should equal(3)
     }
 
     "be identified as number" in {
       JsFloat.fromLiteral(0F).isNumber should equal(true)
+      JsFloat.fromByteStringUnsafe(ByteString("0")).isNumber should equal(true)
+      JsFloat.fromStringUnsafe("0").isNumber should equal(true)
     }
 
     "be identified as float" in {
       JsFloat.fromLiteral(0F).isFloat should equal(true)
+      JsFloat.fromByteStringUnsafe(ByteString("0")).isFloat should equal(true)
+      JsFloat.fromStringUnsafe("0").isFloat should equal(true)
     }
   }
 
   "Json double" should {
     "stringify double correctly" in {
       JsDouble.fromLiteral(1.0D).toString should equal("1.0")
+      JsDouble.fromByteStringUnsafe(ByteString("1.0")).toString should equal("1.0")
+      JsDouble.fromStringUnsafe("1.0").toString should equal("1.0")
     }
 
     "map json double correctly" in {
@@ -521,40 +537,58 @@ class JsonSpec extends WordSpecLike with Matchers {
 
     "return correct size for double" in {
       JsDouble.fromLiteral(2.0D).sizeHint should equal(3)
+      JsDouble.fromByteStringUnsafe(ByteString("2.0")).sizeHint should equal(3)
+      JsDouble.fromStringUnsafe("2.0").sizeHint should equal(3)
     }
 
     "return int conversion for double" in {
       JsDouble.fromLiteral(2.0D).toInt should equal(2)
+      JsDouble.fromByteStringUnsafe(ByteString("2.0")).toInt should equal(2)
+      JsDouble.fromStringUnsafe("2.0").toInt should equal(2)
     }
 
     "return long conversion for double" in {
       JsDouble.fromLiteral(2.0D).toLong should equal(2L)
+      JsDouble.fromByteStringUnsafe(ByteString("2.0")).toLong should equal(2L)
+      JsDouble.fromStringUnsafe("2.0").toLong should equal(2L)
     }
 
     "return float conversion for double" in {
       JsDouble.fromLiteral(2.0D).toFloat should equal(2.0F)
+      JsDouble.fromByteStringUnsafe(ByteString("2.0")).toFloat should equal(2.0F)
+      JsDouble.fromStringUnsafe("2.0").toFloat should equal(2.0F)
     }
 
     "return double conversion for double" in {
       JsDouble.fromLiteral(2.0D).toDouble should equal(2.0D)
+      JsDouble.fromByteStringUnsafe(ByteString("2.0")).toDouble should equal(2.0D)
+      JsDouble.fromStringUnsafe("2.0").toDouble should equal(2.0D)
     }
 
     "return big decimal conversion for double" in {
       JsDouble.fromLiteral(2.0D).toBigDecimal should equal(BigDecimal(2.0D))
+      JsDouble.fromByteStringUnsafe(ByteString("2.0")).toBigDecimal should equal(BigDecimal(2.0D))
+      JsDouble.fromStringUnsafe("2.0").toBigDecimal should equal(BigDecimal(2.0D))
     }
 
     "be identified as number" in {
-      JsDouble.fromLiteral(0D).isNumber should equal(true)
+      JsDouble.fromLiteral(0.0D).isNumber should equal(true)
+      JsDouble.fromByteStringUnsafe(ByteString("0.0")).isNumber should equal(true)
+      JsDouble.fromStringUnsafe("0.0").isNumber should equal(true)
     }
 
     "be identified as double" in {
-      JsDouble.fromLiteral(0D).isDouble should equal(true)
+      JsDouble.fromLiteral(0.0D).isDouble should equal(true)
+      JsDouble.fromByteStringUnsafe(ByteString("0.0")).isDouble should equal(true)
+      JsDouble.fromStringUnsafe("0.0").isDouble should equal(true)
     }
   }
 
   "Json int" should {
     "stringify int correctly" in {
       JsInt.fromLiteral(0).toString should equal("0")
+      JsInt.fromByteStringUnsafe(ByteString("0")).toString should equal("0")
+      JsInt.fromStringUnsafe("0").toString should equal("0")
     }
 
     "return correct size for int" in {
@@ -575,37 +609,52 @@ class JsonSpec extends WordSpecLike with Matchers {
 
     "return int conversion for int" in {
       JsInt.fromLiteral(1).toInt should equal(1)
+      JsInt.fromByteStringUnsafe(ByteString("1")).toInt should equal(1)
+      JsInt.fromStringUnsafe("1").toInt should equal(1)
     }
 
     "return long conversion for int" in {
       JsInt.fromLiteral(1).toLong should equal(1L)
+      JsInt.fromByteStringUnsafe(ByteString("1")).toLong should equal(1L)
+      JsInt.fromStringUnsafe("1").toLong should equal(1L)
     }
 
     "return float conversion for int" in {
       JsInt.fromLiteral(1).toFloat should equal(1.0F)
+      JsInt.fromByteStringUnsafe(ByteString("1")).toFloat should equal(1.0F)
+      JsInt.fromStringUnsafe("1").toFloat should equal(1.0F)
     }
 
     "return double conversion for int" in {
       JsInt.fromLiteral(1).toDouble should equal(1.0D)
+      JsInt.fromByteStringUnsafe(ByteString("1")).toDouble should equal(1.0D)
+      JsInt.fromStringUnsafe("1").toDouble should equal(1.0D)
     }
 
     "return big decimal conversion for int" in {
       JsInt.fromLiteral(1).toBigDecimal should equal(BigDecimal(1))
+      JsInt.fromByteStringUnsafe(ByteString("1")).toBigDecimal should equal(BigDecimal(1))
+      JsInt.fromStringUnsafe("1").toBigDecimal should equal(BigDecimal(1))
     }
 
     "be identified as number" in {
       JsInt.fromLiteral(0).isNumber should equal(true)
+      JsInt.fromByteStringUnsafe(ByteString("0")).isNumber should equal(true)
+      JsInt.fromStringUnsafe("0").isNumber should equal(true)
     }
 
     "be identified as int" in {
       JsInt.fromLiteral(0).isInt should equal(true)
+      JsInt.fromByteStringUnsafe(ByteString("0")).isInt should equal(true)
+      JsInt.fromStringUnsafe("0").isInt should equal(true)
     }
   }
 
   "Json long" should {
     "stringify long integers correctly" in {
-      val input = Json.obj("l" -> 1330950829160L)
-      input.toString should equal("""{"l":1330950829160}""")
+      JsLong.fromLiteral(1330950829160L).toString should equal("1330950829160")
+      JsLong.fromByteStringUnsafe(ByteString("1330950829160")).toString should equal("1330950829160")
+      JsLong.fromStringUnsafe("1330950829160").toString should equal("1330950829160")
     }
 
     "return correct size for long" in {
@@ -626,76 +675,106 @@ class JsonSpec extends WordSpecLike with Matchers {
 
     "return int conversion for long" in {
       JsLong.fromLiteral(1L).toInt should equal(1)
+      JsLong.fromByteStringUnsafe(ByteString("1")).toInt should equal(1)
+      JsLong.fromStringUnsafe("1").toInt should equal(1)
     }
 
     "return long conversion for long" in {
       JsLong.fromLiteral(1L).toLong should equal(1L)
+      JsLong.fromByteStringUnsafe(ByteString("1")).toLong should equal(1L)
+      JsLong.fromStringUnsafe("1").toLong should equal(1L)
     }
 
     "return float conversion for long" in {
       JsLong.fromLiteral(1L).toFloat should equal(1.0F)
+      JsLong.fromByteStringUnsafe(ByteString("1")).toFloat should equal(1.0F)
+      JsLong.fromStringUnsafe("1").toFloat should equal(1.0F)
     }
 
     "return double conversion for long" in {
       JsLong.fromLiteral(1L).toDouble should equal(1.0D)
+      JsLong.fromByteStringUnsafe(ByteString("1")).toDouble should equal(1.0D)
+      JsLong.fromStringUnsafe("1").toDouble should equal(1.0D)
     }
 
     "return big decimal conversion for long" in {
       JsLong.fromLiteral(1L).toBigDecimal should equal(BigDecimal(1))
+      JsLong.fromByteStringUnsafe(ByteString("1")).toBigDecimal should equal(BigDecimal(1))
+      JsLong.fromStringUnsafe("1").toBigDecimal should equal(BigDecimal(1))
     }
 
     "be identified as number" in {
       JsLong.fromLiteral(0).isNumber should equal(true)
+      JsLong.fromByteStringUnsafe(ByteString("0")).isNumber should equal(true)
+      JsLong.fromStringUnsafe("0").isNumber should equal(true)
     }
 
     "be identified as long" in {
       JsLong.fromLiteral(0).isLong should equal(true)
+      JsLong.fromByteStringUnsafe(ByteString("0")).isLong should equal(true)
+      JsLong.fromStringUnsafe("0").isLong should equal(true)
     }
   }
 
   "Json big decimal" should {
     "return correct size for big decimal" in {
       JsBigDecimal.fromLiteral(BigDecimal("2e128")).sizeHint should equal(6)
+      JsBigDecimal.fromByteStringUnsafe(ByteString("2e128")).sizeHint should equal(5)
+      JsBigDecimal.fromStringUnsafe("2e128").sizeHint should equal(5)
     }
 
     "return int conversion for big decimal" in {
-      JsBigDecimal.fromLiteral(BigDecimal(6)).toInt should equal(6)
+      JsBigDecimal.fromLiteral(BigDecimal(6.0D)).toInt should equal(6)
+      JsBigDecimal.fromByteStringUnsafe(ByteString("6.0")).toInt should equal(6)
+      JsBigDecimal.fromStringUnsafe("6.0").toInt should equal(6)
     }
 
     "return long conversion for big decimal" in {
-      JsBigDecimal.fromLiteral(BigDecimal(6L)).toLong should equal(6L)
+      JsBigDecimal.fromLiteral(BigDecimal(6.0D)).toLong should equal(6L)
+      JsBigDecimal.fromByteStringUnsafe(ByteString("6.0")).toLong should equal(6L)
+      JsBigDecimal.fromStringUnsafe("6.0").toLong should equal(6L)
     }
 
     "return double conversion for big decimal" in {
-      JsBigDecimal.fromLiteral(BigDecimal(6.0D)).toDouble should equal(6.0D)
+      JsBigDecimal.fromLiteral(BigDecimal(6.0D)).toDouble should equal(6D)
+      JsBigDecimal.fromByteStringUnsafe(ByteString("6.0")).toInt should equal(6D)
+      JsBigDecimal.fromStringUnsafe("6.0").toInt should equal(6D)
     }
 
     "return big decimal conversion for big decimal" in {
       JsBigDecimal.fromLiteral(BigDecimal("2e128")).toBigDecimal should equal(BigDecimal("2e128"))
+      JsBigDecimal.fromByteStringUnsafe(ByteString("2e128")).toBigDecimal should equal(BigDecimal("2e128"))
+      JsBigDecimal.fromStringUnsafe("2e128").toBigDecimal should equal(BigDecimal("2e128"))
     }
 
     "be identified as big decimal" in {
       JsBigDecimal.fromLiteral(BigDecimal(0F)).isBigDecimal should equal(true)
+      JsBigDecimal.fromByteStringUnsafe(ByteString("0")).isBigDecimal should equal(true)
+      JsBigDecimal.fromStringUnsafe("0").isBigDecimal should equal(true)
     }
   }
 
   "Json string" should {
     "return correct size for string" in {
       JsString.fromLiteral("test").sizeHint should equal(6) // "test"
+      JsString.fromByteStringUnsafe(ByteString("test")).sizeHint should equal(6) // "test"
     }
 
     "be identified as string" in {
       JsString.fromLiteral("").isString should equal(true)
+      JsString.fromByteStringUnsafe(ByteString("")).isString should equal(true)
     }
   }
 
   "Json bytes" should {
     "stringify bytestring correctly" in {
       JsBytes.fromLiteral(ByteString("test")).toString should equal("\"dGVzdA==\"")
+      JsBytes.fromStringUnsafe("test").toString should equal("\"dGVzdA==\"")
     }
 
     "be identified as bytes" in {
       JsBytes.fromLiteral(ByteString.empty).isBytes should equal(true)
+      JsBytes.fromStringUnsafe("").isBytes should equal(true)
     }
   }
 

--- a/core/src/test/scala/io/techcode/streamy/util/lang/CharBuilderSpec.scala
+++ b/core/src/test/scala/io/techcode/streamy/util/lang/CharBuilderSpec.scala
@@ -59,14 +59,14 @@ class CharBuilderSpec extends StreamyTestSystem {
 
     "be able to append an int" in {
       val builder = new CharBuilder
-      builder.append(-10).append(50)
-      builder.toString should equal("-1050")
+      builder.append(-10).append(50).append(Int.MinValue)
+      builder.toString should equal("-1050-2147483648")
     }
 
     "be able to append a long" in {
       val builder = new CharBuilder
-      builder.append(9223372036854775800L)
-      builder.toString should equal("9223372036854775800")
+      builder.append(9223372036854775800L).append(Long.MinValue)
+      builder.toString should equal("9223372036854775800-9223372036854775808")
     }
 
     "be able to append a float" in {

--- a/core/src/test/scala/io/techcode/streamy/util/parser/ByteStringParserSpec.scala
+++ b/core/src/test/scala/io/techcode/streamy/util/parser/ByteStringParserSpec.scala
@@ -446,6 +446,22 @@ class ByteStringParserSpec extends WordSpecLike with Matchers {
       parser.parse(ByteString("foobar")) should equal(Right(Json.obj("foo" -> "foo", "bar" -> "bar")))
     }
 
+    "process correctly when using stack" in {
+      val parser = new ByteStringParserImpl() {
+        override def root(): Boolean = {
+          capture {
+            or(
+              str("123"),
+              str("123")
+            )
+          } { x =>
+            stack.push(x)
+            true
+          }
+        }
+      }
+      parser.parse(ByteString("123123")).isRight should equal(true)
+    }
   }
 
   "Parser exception" should {

--- a/plugin-elasticsearch/src/main/scala/io/techcode/streamy/elasticsearch/component/ElasticsearchFlow.scala
+++ b/plugin-elasticsearch/src/main/scala/io/techcode/streamy/elasticsearch/component/ElasticsearchFlow.scala
@@ -214,7 +214,7 @@ object ElasticsearchFlow {
 
       // Remove extra fields
       val doc = pkt.patch(ElasticOp.RemoveExtraFields).get[Json]
-      header.toByteString ++ NewLineDelimiter ++ doc.toByteString ++ NewLineDelimiter
+      Json.printByteStringUnsafe(header) ++ NewLineDelimiter ++ Json.printByteStringUnsafe(doc) ++ NewLineDelimiter
     }
 
     /**

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -49,15 +49,15 @@ object Dependencies {
 
   import Compile._, Test._
 
-  val akka = libraryDependencies ++= Seq(akkaActor,akkaStream, akkaSlf4j).map(_ % "2.5.27")
+  val akka = libraryDependencies ++= Seq(akkaActor,akkaStream, akkaSlf4j).map(_ % "2.5.29")
   val akkaHttp = libraryDependencies ++= Seq(Compile.akkaHttp).map(_ % "10.1.11")
   val logback = libraryDependencies ++= Seq(logbackClassic % "1.2.3")
-  val guava = libraryDependencies ++= Seq(googleGuava % "28.1-jre")
-  val config = libraryDependencies ++= Seq(pureConfig % "0.12.1")
+  val guava = libraryDependencies ++= Seq(googleGuava % "28.2-jre")
+  val config = libraryDependencies ++= Seq(pureConfig % "0.12.3")
   val scala = libraryDependencies ++= Seq(scalaReflect.value)
   val metric = libraryDependencies ++= Seq(metricsJvm % "4.0.5")
 
-  private val akkaTesting = Seq(akkaTestkit, akkaStreamTestkit).map(_ % "2.5.27")
+  private val akkaTesting = Seq(akkaTestkit, akkaStreamTestkit).map(_ % "2.5.29")
   val akkaTest = libraryDependencies ++= akkaTesting.map(_ % "test")
   val akkaTestLib = libraryDependencies ++= akkaTesting
   val elasticTest = libraryDependencies ++= Seq(elastic).map(_ % "7.3.0" % "test")


### PR DESCRIPTION
Signed-off-by: amannocci <adrien.mannocci@gmail.com>

##### Motivation:

In various cases, we process ByteString in input and create ByteString in output in Streamy pipelines.  
And in many case, we don't care about some values because we are going to just pass it from input to output.  
And due to internal Json structure in Streamy it can be very expensive to process every thing for nothing.  
We need an Unsafe Json API that allow lazy parsing for expensive transformation.  
This will allow to save CPU for input to output transformation because we already have the representation and transformation for unused data.